### PR TITLE
ci(gha): run chart releaser only on chart changed

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - charts/**
 
 jobs:
   release:


### PR DESCRIPTION
Do not run chart releaser CI when there are no file changes on `charts` directory.