### PR TITLE
fix(jellyfin): move transcode cache to PVC to prevent node eviction

### DIFF
--- a/values/jellyfin/backbone.yaml
+++ b/values/jellyfin/backbone.yaml
@@ -113,9 +113,11 @@ volumes:
       path: /dev/rga
     name: rk-rga
   - name: jellyfin-cache
-    emptyDir: {}
+    emptyDir:
+      sizeLimit: 2Gi
   - name: jellyfin-log
-    emptyDir: {}
+    emptyDir:
+      sizeLimit: 500Mi
 
 # -- Additional volume mounts for the Jellyfin container.
 volumeMounts:
@@ -185,6 +187,12 @@ persistence:
     type: hostPath
     # -- Path on the host node for media storage, only used if type is 'hostPath'.
     hostPath: "/mnt/data/media"
+  cache:
+    enabled: true
+    accessMode: ReadWriteOnce
+    size: 50Gi
+    annotations: {}
+    storageClass: hdd-ha-xfs
 
 # -- Configuration for metrics collection and monitoring
 metrics:


### PR DESCRIPTION
## 문제

Jellyfin 트랜스코드 캐시(`/cache`)가 `EmptyDir`로 설정되어 있어 노드의 ephemeral-storage를 소모하고, kubelet eviction threshold(~5.28GB)를 초과하면 pod가 강제 종료됨. 실제로 2회 반복 evict 발생.

## 변경사항

- `persistence.cache.enabled: true` + `storageClass: hdd-ha-xfs` (50Gi)
  - `/cache` (트랜스코드 캐시)를 `hdd-ha-xfs` PVC로 이동 → 루트 파티션과 분리
- `jellyfin-cache` EmptyDir에 `sizeLimit: 2Gi` 추가
- `jellyfin-log` EmptyDir에 `sizeLimit: 500Mi` 추가

## 배경

루트 파티션(`/dev/mmcblk1p3`, 99GB)이 90% 사용 중이었고, 트랜스코딩 시 HLS 세그먼트가 EmptyDir에 쌓여 임계치 아래로 떨어졌음. `hdd-ha-xfs`는 `/mnt/temporal` 기반으로 622GB 여유 공간 있음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)