### PR TITLE
perf(cilium): tighten 1.20 scheduling and metrics operations

### DIFF
--- a/cluster-setup/roles/iptables-firewall/tasks/main.yml
+++ b/cluster-setup/roles/iptables-firewall/tasks/main.yml
@@ -842,6 +842,24 @@
     comment: cilium health check
   when: k8s_role != "" and use_k8s_cilium
 
+- name: Allow k8s cilium agent metrics
+  block:
+    - ansible.builtin.iptables:
+        chain: TCP
+        protocol: tcp
+        destination_port: 9962
+        jump: ACCEPT
+        source: "{{ __register_k8s_internal_node_ip_cidr }}"
+        comment: cilium agent metrics
+    - ansible.builtin.iptables:
+        chain: TCP
+        protocol: tcp
+        destination_port: 9962
+        jump: ACCEPT
+        source: "{{ k8s_pod_cidr }}"
+        comment: cilium agent metrics
+  when: k8s_role != "" and use_k8s_cilium
+
 - name: Allow k8s cilium hubble
   block:
     - ansible.builtin.iptables:
@@ -858,6 +876,24 @@
         jump: ACCEPT
         source: "{{ k8s_pod_cidr }}"
         comment: cilium hubble
+  when: k8s_role != "" and use_k8s_cilium_hubble
+
+- name: Allow k8s cilium hubble metrics
+  block:
+    - ansible.builtin.iptables:
+        chain: TCP
+        protocol: tcp
+        destination_port: 9965
+        jump: ACCEPT
+        source: "{{ __register_k8s_internal_node_ip_cidr }}"
+        comment: cilium hubble metrics
+    - ansible.builtin.iptables:
+        chain: TCP
+        protocol: tcp
+        destination_port: 9965
+        jump: ACCEPT
+        source: "{{ k8s_pod_cidr }}"
+        comment: cilium hubble metrics
   when: k8s_role != "" and use_k8s_cilium_hubble
 
 - name: Allow k8s metallb L2 LB

--- a/values/cilium/backbone.yaml
+++ b/values/cilium/backbone.yaml
@@ -14,6 +14,11 @@
 # compatibility fixes do not affect the running agent process.
 rollOutCiliumPods: true
 
+# Agent metrics hostPorts already guarantee one Cilium pod per node, so let the
+# scheduler use its native hostPort conflict handling instead of pod anti-affinity.
+scheduling:
+  mode: kube-scheduler
+
 # ─── k3s API server (KPR 필수) ───
 k8sServiceHost: k8s.backbone.homelab.bhyoo.com
 k8sServicePort: 6443
@@ -87,15 +92,17 @@ bpf:
   # 모니터링 이벤트 집계 (CPU 부하 감소)
   monitorAggregation: medium
   monitorInterval: "5s"
-  # BPF clock probe (jiffies 대신 ktime, 더 정확한 CT 타임스탬프)
-  # 신규 설치에서만 안전
+  # Probe for the lower-overhead jiffies clock used by CT maps; kernels that do
+  # not support it automatically retain ktime (currently n2p1/n2p2).
 bpfClockProbe: true
 
 # Pod 트래픽이 iptables conntrack을 거치지 않도록 우회 (native routing + full KPR + bpf.masquerade 전제)
 installNoConntrackIptablesRules: false
 
 # ─── Bandwidth Manager + BBR ───
-# BBR 혼잡 제어 (커널 5.18+, 전 노드 해당). CUBIC 대비 처리량↑, 지연↓
+# EDT remains active, but BBR requires eBPF host routing for reliable pacing.
+# Current no-BTF masquerade fallback leaves Host Routing in Legacy mode; keep
+# this enabled so BBR becomes effective again when BPF host routing is restored.
 bandwidthManager:
   enabled: true
   bbr: true


### PR DESCRIPTION
## 문제

Cilium 1.20.0 및 ADS 전환 후 기능 경로는 정상이나, 운영 상태에서 다음 비효율을 확인했습니다.

- `cilium-agent` Prometheus target 5/5 down: node TCP 9962 connection refused
- `hubble-metrics` Prometheus target 5/5 down: node TCP 9965 connection refused
- Cilium agent DaemonSet가 hostPort 9879/4244/9962/9965를 사용하면서도 hostname pod anti-affinity를 중복 적용
- `bpfClockProbe`와 BBR 주석이 실제 1.20 동작 및 현재 no-BTF fallback 상태와 불일치

## 변경

- `scheduling.mode: kube-scheduler`를 사용해 hostPort 충돌 감지에 스케줄링을 맡기고 중복 pod anti-affinity 제거
- backbone 방화벽에서 내부 노드 CIDR 및 Pod CIDR에 한해 Cilium agent metrics TCP 9962 허용
- Hubble 사용 노드에서 내부 노드 CIDR 및 Pod CIDR에 한해 Hubble metrics TCP 9965 허용
- `bpfClockProbe`가 jiffies 지원을 probe하고 미지원 커널은 ktime을 유지한다는 설명으로 수정
- 현재 `bpf.masquerade=false`/Legacy Host Routing에서는 EDT는 활성이나 BBR pacing 이점이 제한된다는 설명 추가

## 검증

- Helm 1.20.0 render: 38 objects
- `envoy-xds-mode=ads` 유지
- Cilium agent affinity 제거 확인
- hostPort 9879/4244/9962/9965 유지 확인
- Cilium 및 standalone Envoy ConfigMap checksum rollout 유지 확인
- server-side diff 성공; 변경 대상은 Cilium DaemonSet scheduling 부분
- Ansible firewall role task syntax check 성공 (`ansible-core` + `community.general`)
- `git diff --check` 성공
- 현재 live firewall에 9962/9965 Pod CIDR ACCEPT rule이 없음을 재현

## 배포 순서

1. merge 후 ArgoCD가 Cilium scheduling 변경을 적용하는 동안 agent 5/5 rollout 확인
2. `cluster-setup` firewall playbook을 backbone 노드에 적용
3. Prometheus에서 `cilium-agent` 5/5 및 `hubble-metrics` 5/5 target이 up인지 확인
4. `cilium_drift_checker_config_delta`가 모든 node에서 0인지 확인

방화벽 변경은 ArgoCD 대상이 아니므로 merge만으로 metrics scrape가 복구되지는 않습니다.

## 검토했으나 제외한 1.20 기능

- eBPF masquerade/host routing: 전 노드 `/sys/kernel/btf/vmlinux` 부재로 1.20 global SNAT BPF 로드 실패. 현재 iptables fallback 유지
- XDP acceleration: 전용 NIC/고 PPS 병목 증거가 없고 native-driver/CPU 위험이 이득보다 큼
- Maglev: 현재 소규모 homelab에서 메모리 비용 대비 session-affinity 이점이 불명확
- LRU/CT map 추가 조정: 현재 map pressure 또는 eviction 근거 없음
- per-node configuration: 노드별 datapath 설정 차이가 없어 운영 복잡도만 증가
