### PR TITLE
feat(nix): enable K3s graceful node shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ inventory의 `[nix_managed]`와 `ansible_host`에서 `hosts_dns_hostname`으로 
 Peer 변경은 `nix run .#rollout-peers -- <host>`로 수행한다. K3s binary/version
 rollout은 계속 Rancher `system-upgrade-controller`가 소유한다.
 
+### Graceful node shutdown
+
+K3s node 6대(`n2p1`, `n2p2`, `rpi4`, `rpi5`, `rock5bp`, `macmini`)는 priority별로 순차 종료한다. 일반 workload(priority 0)는 60초, ZFS CSI(priority 900000000 이상)는 45초, `system-cluster-critical`은 30초, `system-node-critical`은 45초다. 현재 일반 Pod의 표준 종료 예산은 최대 30초이고 ZFS 및 democratic-csi node Pod는 30초와 `preStop`/volume unmount 작업을 사용한다. 전체 kubelet 예산은 180초이며 logind `InhibitDelayMaxSec=195s`가 15초의 감지·해제 여유를 둔다.
+
+CNPG의 1800초와 Prometheus의 600초 종료 예산은 일반 reboot에 그대로 반영하지 않는다. 이를 반영하면 모든 node의 machine-wide inhibitor가 30분 이상으로 늘어난다. 해당 workload가 있는 node의 계획 유지보수는 CNPG switchover와 `kubectl drain`으로 처리한다. `n2p1`, `n2p2`에서는 unattended-upgrades의 같은 이름 30초 drop-in을 `/dev/null`로 마스킹한다. `activate`는 logind를 먼저 재시작한 뒤 K3s를 재시작하며, `verify-host`는 merged logind 값, kubelet inhibitor, API의 active priority별 kubelet config를 확인한다.
+
+구성 적용 후 일반 재부팅은 `systemctl reboot`를 사용한다. 이 경로는 kubelet의 정상 Pod 종료 기회를 제공하지만 PDB eviction, 대체 Pod의 Ready 완료, 단일 replica 무중단, local PV 이동을 보장하지 않는다. 먼저 `n2p1`, `n2p2`에서 검증하고 control-plane/etcd node는 quorum을 위해 항상 한 번에 하나씩 재부팅한다. `reboot -f`와 `systemctl reboot --force`는 사용하지 않는다.
+
 ## Verification
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,42 @@
               rockResolved = rock.environment.etc."systemd/resolved.conf".text;
               rockSsh = rock.environment.etc."ssh/sshd_config".text;
               rockCommitSsh = self.systemConfigs."rock5bp-commit".config.environment.etc."ssh/sshd_config".text;
+              gracefulShutdownSourcePath = "homelab/kubelet/10-graceful-node-shutdown.conf";
+              logindShutdownPath = "systemd/logind.conf.d/zz-kubelet-graceful-shutdown.conf";
+              unattendedLogindPath = "systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf";
+              gracefulShutdownConfigured = lib.all (
+                hostName:
+                let
+                  cfg = self.systemConfigs.${hostName}.config;
+                in
+                if linuxHosts.${hostName}.k3sRole == null then
+                  !(builtins.hasAttr gracefulShutdownSourcePath cfg.environment.etc)
+                  && !(lib.any (
+                    rule:
+                    lib.hasInfix "/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf" rule
+                  ) cfg.systemd.tmpfiles.rules)
+                  && !(builtins.hasAttr logindShutdownPath cfg.environment.etc)
+                else
+                  cfg.environment.etc.${gracefulShutdownSourcePath}.text == ''
+                    apiVersion: kubelet.config.k8s.io/v1beta1
+                    kind: KubeletConfiguration
+                    shutdownGracePeriodByPodPriority:
+                      - priority: 0
+                        shutdownGracePeriodSeconds: 60
+                      - priority: 900000000
+                        shutdownGracePeriodSeconds: 45
+                      - priority: 2000000000
+                        shutdownGracePeriodSeconds: 30
+                      - priority: 2000001000
+                        shutdownGracePeriodSeconds: 45
+                  ''
+                  && builtins.elem "L+ /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf - - - - /etc/homelab/kubelet/10-graceful-node-shutdown.conf" cfg.systemd.tmpfiles.rules
+                  &&
+                    cfg.environment.etc.${logindShutdownPath}.text == ''
+                      [Login]
+                      InhibitDelayMaxSec=195s
+                    ''
+              ) (builtins.attrNames linuxHosts);
               projectServices =
                 cfg:
                 lib.filter (service: lib.hasPrefix "homelab-" service) (builtins.attrNames cfg.systemd.services);
@@ -218,6 +254,9 @@
               rock.environment.etc;
             assert builtins.length topology.requiredLinks == 35;
             assert !(builtins.hasAttr "wg1" topology);
+            assert gracefulShutdownConfigured;
+            assert toString n2p1.environment.etc.${unattendedLogindPath}.source == "/dev/null";
+            assert !(builtins.hasAttr unattendedLogindPath rock.environment.etc);
             assert lib.hasInfix "Address=192.168.219.6/24"
               rock.environment.etc."systemd/network/10-homelab-lan.network".text;
             assert lib.hasInfix "Endpoint=192.168.219.3:51902" rockWg;

--- a/nix/modules/linux/k3s-host.nix
+++ b/nix/modules/linux/k3s-host.nix
@@ -15,6 +15,34 @@ let
     else
       "netfilter-persistent.service";
   server = hostConfig.k3sRole == "server";
+  maskUnattendedUpgradesLogindDelay = builtins.elem name [
+    "n2p1"
+    "n2p2"
+  ];
+  shutdownPriorities = {
+    workloads = 0;
+    zfsCsi = 900000000;
+    systemClusterCritical = 2000000000;
+    systemNodeCritical = 2000001000;
+  };
+  shutdownGracePeriods = {
+    # Ordinary pods currently request at most 30s. CNPG and Prometheus use
+    # 600s/1800s and remain drain-only rather than imposing a 30-minute
+    # machine-wide inhibitor on every node.
+    workloads = 60;
+    # ZFS CSI and system-node-critical CSI pods request 30s and have preStop
+    # or volume-unmount work, so their phases retain a 15s cleanup margin.
+    zfsCsi = 45;
+    systemClusterCritical = 30;
+    systemNodeCritical = 45;
+  };
+  shutdownGracePeriodTotalSeconds =
+    shutdownGracePeriods.workloads
+    + shutdownGracePeriods.zfsCsi
+    + shutdownGracePeriods.systemClusterCritical
+    + shutdownGracePeriods.systemNodeCritical;
+  shutdownInhibitMarginSeconds = 15;
+  shutdownInhibitDelaySeconds = shutdownGracePeriodTotalSeconds + shutdownInhibitMarginSeconds;
   wg0Address = topology.wg0.nodes.${name}.address or null;
   strip = address: if address == null then null else builtins.head (lib.splitString "/" address);
   tokenPath = config.homelab.k3s.tokenPath;
@@ -139,30 +167,74 @@ in
   };
 
   config = lib.mkIf enabled {
-    environment.etc."rancher/k3s/config.yaml" = {
-      text =
-        serverConfig
-        + lib.optionalString (
-          hostConfig.k3sLabels != [ ]
-        ) "\nnode-label:\n${yamlList hostConfig.k3sLabels}\n";
-      replaceExisting = true;
-      mode = "0600";
+    environment.etc = {
+      "rancher/k3s/config.yaml" = {
+        text =
+          serverConfig
+          + lib.optionalString (
+            hostConfig.k3sLabels != [ ]
+          ) "\nnode-label:\n${yamlList hostConfig.k3sLabels}\n";
+        replaceExisting = true;
+        mode = "0600";
+      };
+      "homelab/kubelet/10-graceful-node-shutdown.conf" = {
+        text = ''
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          kind: KubeletConfiguration
+          shutdownGracePeriodByPodPriority:
+            - priority: ${toString shutdownPriorities.workloads}
+              shutdownGracePeriodSeconds: ${toString shutdownGracePeriods.workloads}
+            - priority: ${toString shutdownPriorities.zfsCsi}
+              shutdownGracePeriodSeconds: ${toString shutdownGracePeriods.zfsCsi}
+            - priority: ${toString shutdownPriorities.systemClusterCritical}
+              shutdownGracePeriodSeconds: ${toString shutdownGracePeriods.systemClusterCritical}
+            - priority: ${toString shutdownPriorities.systemNodeCritical}
+              shutdownGracePeriodSeconds: ${toString shutdownGracePeriods.systemNodeCritical}
+        '';
+        replaceExisting = true;
+        mode = "0644";
+      };
+      "systemd/logind.conf.d/zz-kubelet-graceful-shutdown.conf" = {
+        text = ''
+          [Login]
+          InhibitDelayMaxSec=${toString shutdownInhibitDelaySeconds}s
+        '';
+        replaceExisting = true;
+        mode = "0644";
+      };
+      "rancher/k3s/registries.yaml" = {
+        text = ''
+          mirrors:
+            docker.io:
+              endpoint:
+                - "http://127.0.0.1:30500"
+            ghcr.io:
+              endpoint:
+                - "http://127.0.0.1:30501"
+        '';
+        replaceExisting = true;
+        mode = "0644";
+      };
+    }
+    // lib.optionalAttrs maskUnattendedUpgradesLogindDelay {
+      "systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf" = {
+        source = "/dev/null";
+        replaceExisting = true;
+      };
     };
-    # NodePorts 30500/30501 are the docker.io/ghcr.io pull-through caches
-    # in apps/objects/registry-mirror. containerd on the node cannot use
-    # ClusterIP DNS, so kubelet pulls via loopback NodePort.
-    environment.etc."rancher/k3s/registries.yaml" = {
-      text = ''
-        mirrors:
-          docker.io:
-            endpoint:
-              - "http://127.0.0.1:30500"
-          ghcr.io:
-            endpoint:
-              - "http://127.0.0.1:30501"
+    systemd.tmpfiles.rules = [
+      "d /var/lib/rancher/k3s/agent/etc/kubelet.conf.d 0755 root root -"
+      "L+ /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf - - - - /etc/homelab/kubelet/10-graceful-node-shutdown.conf"
+    ];
+    system-manager.preActivationAssertions.kubeletGracefulShutdownPath = {
+      enable = true;
+      script = ''
+        path=/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf
+        test ! -e "$path" && test ! -L "$path" && exit 0
+        test "$(readlink "$path" 2>/dev/null || true)" = /etc/homelab/kubelet/10-graceful-node-shutdown.conf && exit 0
+        echo "$path already exists and is not managed by system-manager" >&2
+        exit 1
       '';
-      replaceExisting = true;
-      mode = "0644";
     };
     systemd.services.homelab-k3s = {
       description = "Run K3s ${if server then "server" else "agent"}";

--- a/nix/scripts/check-migration.py
+++ b/nix/scripts/check-migration.py
@@ -4733,6 +4733,41 @@ forbid(
     "k3sPackage",
     "../../k3s-package.nix",
 )
+require(
+    "nix/modules/linux/k3s-host.nix",
+    "10-graceful-node-shutdown.conf",
+    "homelab/kubelet/10-graceful-node-shutdown.conf",
+    "shutdownGracePeriodByPodPriority:",
+    "zfsCsi = 900000000;",
+    "systemClusterCritical = 2000000000;",
+    "systemNodeCritical = 2000001000;",
+    "shutdownGracePeriodSeconds: ${toString shutdownGracePeriods.workloads}",
+    "shutdownGracePeriodSeconds: ${toString shutdownGracePeriods.zfsCsi}",
+    "shutdownGracePeriodSeconds: ${toString shutdownGracePeriods.systemNodeCritical}",
+    "workloads = 60;",
+    "zfsCsi = 45;",
+    "systemClusterCritical = 30;",
+    "systemNodeCritical = 45;",
+    "zz-kubelet-graceful-shutdown.conf",
+    "InhibitDelayMaxSec=${toString shutdownInhibitDelaySeconds}s",
+    "unattended-upgrades-logind-maxdelay.conf",
+    "L+ /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf",
+    "kubeletGracefulShutdownPath",
+    'source = "/dev/null"',
+)
+forbid(
+    "nix/modules/linux/k3s-host.nix",
+    "shutdownGracePeriod: 60s",
+    "shutdownGracePeriodCriticalPods: 20s",
+)
+require(
+    "nix/scripts/homelab-host",
+    "systemctl restart systemd-logind.service",
+    "systemd-analyze cat-config systemd/logind.conf",
+    "systemd-inhibit --list --no-pager",
+    "/api/v1/nodes/$host/proxy/configz",
+    "cleanup_unmanaged_kubelet_shutdown_link",
+)
 forbid("nix/modules/linux/k3s-host.nix", "homelab-k3s-legacy-cleanup =")
 forbid("nix/modules/linux/k3s-host.nix", 'Type = if server then "notify" else "exec";')
 forbid(

--- a/nix/scripts/homelab-host
+++ b/nix/scripts/homelab-host
@@ -561,6 +561,9 @@ if test "$MANAGE_FIREWALL_RULES" = true; then
   place_jump FORWARD HOMELAB_FORWARD "$forward_position"
 fi
 if test "$ROLE" = server || test "$ROLE" = agent; then
+  systemctl restart systemd-logind.service
+fi
+if test "$ROLE" = server || test "$ROLE" = agent; then
   systemctl restart homelab-k3s.service
   if test "$ROLE" = server; then
     attempt=0
@@ -1119,6 +1122,14 @@ record_rolled_back() {
     echo "$host rollback is recorded locally, but recovery artifact cleanup failed; rerun a phase-gated command or nix run .#k3s-handoff -- cleanup-restored $host" >&2
     return 1
   fi
+}
+cleanup_unmanaged_kubelet_shutdown_link() {
+  local host=$1
+  remote "$host" 'sudo -n sh -ceu '\''
+    path=/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf
+    test "$(readlink "$path" 2>/dev/null || true)" = /etc/homelab/kubelet/10-graceful-node-shutdown.conf || exit 0
+    grep -Fq "$path" /etc/tmpfiles.d/00-system-manager.conf 2>/dev/null || rm -f "$path"
+  '\'''
 }
 rollback_armed_host() {
   local host=$1 attempt=1
@@ -1701,6 +1712,8 @@ REMOTE_K3S_CLEANUP
     local_network=$(nix_eval --raw "$root#systemConfigs.$host.config.homelab.firewall.localNetwork")
     localtime_source=$(nix_eval --raw "$root#systemConfigs.$host.config.environment.etc.localtime.source")
     resolved_dns_over_tls=$(host_field "$host" resolvedDnsOverTls)
+    mask_unattended_logind_delay=false
+    case "$host" in n2p1|n2p2) mask_unattended_logind_delay=true ;; esac
     if [ "$backend" = pacman ]; then
       firewall_rules=/etc/iptables/iptables.rules
       firewall_service=iptables.service
@@ -1717,10 +1730,11 @@ REMOTE_K3S_CLEANUP
       democratic_csi_key_sha=$(sha256sum "$root/ssh_pub_keys/democratic-csi.pub" | awk '{print $1}')
     fi
     printf -v verify_command \
-      'env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin HOST_NAME=%q ROLE=%q ISCSI_CLIENT=%q ISCSI_LOGIN_SERVICE=%q ISCSI_SERVER=%q PRESERVE_NAS_STATE=%q MANAGE_FIREWALL_RULES=%q ZRAM=%q DEMOCRATIC_CSI_KEY_SHA=%q LAN_ADDRESS=%q GATEWAY_ADDRESS=%q DEFAULT_INTERFACE=%q FIREWALL_RULES=%q FIREWALL_SERVICE=%q SSH_SERVICE=%q ADMIN_USER=%q SAMBA_CLIENTS=%q NETBIOS=%q LOCAL_NETWORK=%q LOCALTIME_SOURCE=%q RESOLVED_DNS_OVER_TLS=%q sh -s' \
+      'env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin HOST_NAME=%q ROLE=%q ISCSI_CLIENT=%q ISCSI_LOGIN_SERVICE=%q ISCSI_SERVER=%q PRESERVE_NAS_STATE=%q MANAGE_FIREWALL_RULES=%q ZRAM=%q DEMOCRATIC_CSI_KEY_SHA=%q LAN_ADDRESS=%q GATEWAY_ADDRESS=%q DEFAULT_INTERFACE=%q FIREWALL_RULES=%q FIREWALL_SERVICE=%q SSH_SERVICE=%q ADMIN_USER=%q SAMBA_CLIENTS=%q NETBIOS=%q LOCAL_NETWORK=%q LOCALTIME_SOURCE=%q RESOLVED_DNS_OVER_TLS=%q MASK_UNATTENDED_LOGIND_DELAY=%q sh -s' \
       "$host" "$role" "$iscsi_client" "$iscsi_login_service" "$iscsi_server" "$preserve" "$manage_rules" "$zram" "$democratic_csi_key_sha" \
       "$lan_address" "$gateway_address" "$default_interface" "$firewall_rules" "$firewall_service" "$ssh_service" \
-      "$admin_user" "$samba_clients" "$netbios" "$local_network" "$localtime_source" "$resolved_dns_over_tls"
+      "$admin_user" "$samba_clients" "$netbios" "$local_network" "$localtime_source" "$resolved_dns_over_tls" \
+      "$mask_unattended_logind_delay"
     remote "$host" "$verify_command" <<'REMOTE_VERIFY'
 set -eu
 stage=core-services
@@ -1789,6 +1803,10 @@ if test "$ADMIN_USER" != root; then
 fi
 stage=firewall
 if test "$MANAGE_FIREWALL_RULES" = true; then test -s "$FIREWALL_RULES"; fi
+test "$(systemd-analyze cat-config systemd/logind.conf | sed -n 's/^[[:space:]]*InhibitDelayMaxSec=//p' | tail -n 1)" = 195s
+if test "$MASK_UNATTENDED_LOGIND_DELAY" = true; then
+  test "$(readlink -f /etc/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf)" = /dev/null
+fi
 for unit in homelab-host-settings.service homelab-wireguard.service homelab-firewall.service homelab-runtime-tuning.service homelab-k3s-legacy-cleanup.service homelab-legacy-tuning-cleanup.service; do
   ! systemctl cat "$unit" >/dev/null 2>&1
 done
@@ -1829,6 +1847,13 @@ if test "$ROLE" = server || test "$ROLE" = agent; then
   stage=k3s-credential-config
   sudo -n test -s /var/lib/homelab-secrets/active/k3s-token.cred
   systemctl cat homelab-k3s.service | grep -Fx 'LoadCredentialEncrypted=k3s-token:/var/lib/homelab-secrets/active/k3s-token.cred'
+  stage=k3s-graceful-shutdown
+  shutdown_config=/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf
+  grep -qx "shutdownGracePeriodByPodPriority:" "$shutdown_config"
+  test "$(grep -c '^  - priority:' "$shutdown_config")" -eq 4
+  ! grep -q '^shutdownGracePeriod:' "$shutdown_config"
+  ! grep -q '^shutdownGracePeriodCriticalPods:' "$shutdown_config"
+  systemd-inhibit --list --no-pager | grep -qi kubelet
   if test "$MANAGE_FIREWALL_RULES" = true; then
   stage=k3s-firewall
   attempt=0
@@ -1900,6 +1925,17 @@ REMOTE_VERIFY
         echo "$host Kubernetes Node Ready is ${node_ready:-missing}" >&2
         exit 1
       }
+      kubectl --context "$context" get --raw "/api/v1/nodes/$host/proxy/configz" \
+        | jq -e '
+            .kubeletconfig.shutdownGracePeriod == "0s"
+            and .kubeletconfig.shutdownGracePeriodCriticalPods == "0s"
+            and .kubeletconfig.shutdownGracePeriodByPodPriority == [
+              {"priority": 0, "shutdownGracePeriodSeconds": 60},
+              {"priority": 900000000, "shutdownGracePeriodSeconds": 45},
+              {"priority": 2000000000, "shutdownGracePeriodSeconds": 30},
+              {"priority": 2000001000, "shutdownGracePeriodSeconds": 45}
+            ]
+          ' >/dev/null
     fi
     ;;
   restore-host)
@@ -1923,6 +1959,7 @@ REMOTE_VERIFY
       test -x \"\$profile/bin/activate\"
       \"\$profile/bin/activate\"
     '"
+    cleanup_unmanaged_kubelet_shutdown_link "$host"
     apply_native_runtime "$host"
     "$0" verify-host "$host"
     ;;

--- a/nix/scripts/homelab-host
+++ b/nix/scripts/homelab-host
@@ -1803,10 +1803,6 @@ if test "$ADMIN_USER" != root; then
 fi
 stage=firewall
 if test "$MANAGE_FIREWALL_RULES" = true; then test -s "$FIREWALL_RULES"; fi
-test "$(systemd-analyze cat-config systemd/logind.conf | sed -n 's/^[[:space:]]*InhibitDelayMaxSec=//p' | tail -n 1)" = 195s
-if test "$MASK_UNATTENDED_LOGIND_DELAY" = true; then
-  test "$(readlink -f /etc/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf)" = /dev/null
-fi
 for unit in homelab-host-settings.service homelab-wireguard.service homelab-firewall.service homelab-runtime-tuning.service homelab-k3s-legacy-cleanup.service homelab-legacy-tuning-cleanup.service; do
   ! systemctl cat "$unit" >/dev/null 2>&1
 done
@@ -1853,6 +1849,14 @@ if test "$ROLE" = server || test "$ROLE" = agent; then
   test "$(grep -c '^  - priority:' "$shutdown_config")" -eq 4
   ! grep -q '^shutdownGracePeriod:' "$shutdown_config"
   ! grep -q '^shutdownGracePeriodCriticalPods:' "$shutdown_config"
+  inhibit=$(systemd-analyze cat-config systemd/logind.conf | sed -n 's/^[[:space:]]*InhibitDelayMaxSec=//p' | tail -n 1)
+  case "$inhibit" in
+    195|195s|"3min 15s") ;;
+    *) echo "InhibitDelayMaxSec is ${inhibit:-missing}, expected 195s" >&2; exit 1 ;;
+  esac
+  if test "$MASK_UNATTENDED_LOGIND_DELAY" = true; then
+    test "$(readlink -f /etc/systemd/logind.conf.d/unattended-upgrades-logind-maxdelay.conf)" = /dev/null
+  fi
   systemd-inhibit --list --no-pager | grep -qi kubelet
   if test "$MANAGE_FIREWALL_RULES" = true; then
   stage=k3s-firewall

--- a/nix/scripts/k3s-handoff
+++ b/nix/scripts/k3s-handoff
@@ -400,6 +400,10 @@ if ! test -e "$stages/system-manager-restored"; then
       exit "$rc"
     }
   fi
+  path=/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf
+  if test "$(readlink "$path" 2>/dev/null || true)" = /etc/homelab/kubelet/10-graceful-node-shutdown.conf; then
+    grep -Fq "$path" /etc/tmpfiles.d/00-system-manager.conf 2>/dev/null || rm -f "$path"
+  fi
   touch "$stages/system-manager-restored"
 fi
 if ! test -e "$stages/archive-restored"; then


### PR DESCRIPTION
## Stack

- Rebased onto current `master` after #287 merged.
- Unique change is still one commit: graceful node shutdown.

## Summary

K3s node 6대(`n2p1`, `n2p2`, `rpi4`, `rpi5`, `rock5bp`, `macmini`)에 kubelet Graceful Node Shutdown을 선언형으로 구성한다. 기존 60초/critical 20초 초안은 live workload의 종료 예산과 CSI 순서를 충족하지 못해 priority별 4단계 정책으로 교체했다.

## Timing policy

| Phase | Priority threshold | Budget | 근거 |
|---|---:|---:|---|
| 일반 workload | `0` | 60초 | 일반 Pod의 표준 종료 예산은 최대 30초. 30초 여유를 둔다. |
| ZFS CSI | `900000000` | 45초 | ZFS CSI Pod는 30초이며 node plugin에 `preStop`이 있다. |
| cluster critical | `2000000000` | 30초 | 현재 `system-cluster-critical` Pod의 종료 예산은 30초다. |
| node critical | `2000001000` | 45초 | democratic-csi node Pod는 30초 `preStop` cleanup과 volume unmount가 필요하다. |

Kubelet은 낮은 priority group부터 순차 처리하고 빈 group은 기다리지 않는다. 최대 kubelet 예산은 180초다. logind는 `InhibitDelayMaxSec=195s`로 설정해 감지·상태 갱신·inhibitor 해제에 15초 여유를 둔다.

CNPG의 1800초와 Prometheus의 600초 종료 예산은 일반 reboot 정책에 포함하지 않는다. 이를 포함하면 모든 node의 machine-wide inhibitor가 30분 이상이 된다. 해당 workload가 있는 node의 계획 유지보수는 CNPG switchover와 `kubectl drain`으로 처리한다.

## Changes

- kubelet drop-in 원본을 `/etc/homelab/kubelet/10-graceful-node-shutdown.conf`로 관리하고 systemd-tmpfiles가 요구 경로 `/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/10-graceful-node-shutdown.conf`에 연결한다.
- `shutdownGracePeriodByPodPriority`로 일반 workload, ZFS CSI, cluster-critical, node-critical 종료 단계를 분리한다.
- `n2p1`, `n2p2`의 unattended-upgrades 30초 override를 `/dev/null`로 마스킹한다.
- activation에서 logind를 K3s보다 먼저 재시작한다.
- `verify-host`가 merged logind 값, kubelet inhibitor, active kubelet `configz`의 priority별 설정을 검증한다.
- rollback/deactivation 시 이전 generation이 tmpfiles rule을 소유하지 않으면 관리하던 `/var/lib` symlink를 제거한다.
- rendered contract와 migration contract에 K3s 적용, non-K3s 제외, worker-only mask를 고정한다.

## Operational boundary

Graceful Node Shutdown은 PDB eviction, 대체 Pod Ready 완료, 단일 replica 무중단, local PV 이동을 보장하지 않는다. Control-plane/etcd node는 한 번에 하나씩만 재부팅한다.

## Validation

- `bash -n nix/scripts/homelab-host nix/scripts/k3s-handoff`
- `python3 nix/scripts/check-topology.py`
- `python3 nix/scripts/check-migration.py`
- `nix flake check --all-systems --no-build --accept-flake-config`
- `git diff --check`

실호스트 activation과 실제 reboot 시험은 수행하지 않았다. 첫 rollout은 `n2p1` 또는 `n2p2` 한 대에서 `configz`, `systemd-analyze cat-config`, `systemd-inhibit`, Pod 종료와 Node Ready 복귀를 관찰해야 한다.