### PR TITLE
fix(nix): use native ssh for macOS operators

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -4,30 +4,38 @@
   topology,
 }:
 let
-  runtimeInputs = with pkgs; [
-    age
-    bash
-    coreutils
-    curl
-    git
-    gawk
-    findutils
-    gnugrep
-    gnused
-    gnutar
-    jq
-    kubectl
-    kubernetes-helm
-    kubernetes-helmPlugins.helm-diff
-    nix
-    openssh
-    openssl
-    python3
-    sops
-    opentofu
-    wireguard-tools
-    yq-go
-  ];
+  # macOS can reject LAN connections from Nix OpenSSH while allowing /usr/bin/ssh.
+  # Prefer the native client for operator sessions, while retaining packaged
+  # OpenSSH for Linux and companion utilities.
+  darwinNativeSsh = pkgs.writeShellScriptBin "ssh" ''
+    exec /usr/bin/ssh "$@"
+  '';
+  runtimeInputs =
+    pkgs.lib.optionals pkgs.stdenv.isDarwin [ darwinNativeSsh ]
+    ++ (with pkgs; [
+      age
+      bash
+      coreutils
+      curl
+      git
+      gawk
+      findutils
+      gnugrep
+      gnused
+      gnutar
+      jq
+      kubectl
+      kubernetes-helm
+      kubernetes-helmPlugins.helm-diff
+      nix
+      openssh
+      openssl
+      python3
+      sops
+      opentofu
+      wireguard-tools
+      yq-go
+    ]);
   mkApp =
     name: description: script: prefix:
     pkgs.writeShellApplication {
@@ -55,8 +63,7 @@ in
       "bootstrap-host";
   homelab-host = hostApp "homelab-host" "Manage declarative homelab hosts" "";
   adopt-host =
-    mkApp "adopt-host" "Capture the pre-Nix state of an existing Linux host"
-      ./scripts/adopt-host
+    mkApp "adopt-host" "Capture the pre-Nix state of an existing Linux host" ./scripts/adopt-host
       "";
   reconcile-host =
     hostApp "reconcile-host" "Idempotently converge an active Nix-owned Linux host"
@@ -66,7 +73,8 @@ in
       ./scripts/rollout-peers
       "";
   provision-host =
-    mkApp "provision-host" "Provision a Git-declared new Linux host" ./scripts/provision-host "";
+    mkApp "provision-host" "Provision a Git-declared new Linux host" ./scripts/provision-host
+      "";
   decommission-host =
     mkApp "decommission-host" "Remove a declared decommissioning host from active peers"
       ./scripts/decommission-host

--- a/nix/scripts/check-migration.py
+++ b/nix/scripts/check-migration.py
@@ -3996,8 +3996,15 @@ require(
     "findutils",
     "gnutar",
     "opentofu",
+    "darwinNativeSsh",
+    'exec /usr/bin/ssh "$@"',
+    "pkgs.lib.optionals pkgs.stdenv.isDarwin [ darwinNativeSsh ]",
     "bootstrap-host",
 )
+package_apps = source("nix/packages.nix")
+runtime_input_expression = package_apps.split("runtimeInputs =", 1)[1].split("]);", 1)[0]
+if runtime_input_expression.index("darwinNativeSsh") > runtime_input_expression.index("openssh"):
+    raise SystemExit("nix/packages.nix: Darwin native ssh must precede packaged OpenSSH")
 for relative in (
     "nix/scripts/wireguard-secrets",
     "nix/scripts/sync-bootstrap-secret",


### PR DESCRIPTION
## Summary
- macOS operator apps에서 Nix OpenSSH보다 `/usr/bin/ssh`를 먼저 사용하도록 한다
- Linux에서는 기존 packaged OpenSSH 경로를 유지한다
- native SSH adapter가 packaged OpenSSH 뒤로 밀리면 migration contract가 실패하도록 고정한다

## Reason
PR #287 병합 후 현재 macOS에서 packaged OpenSSH 10.4는 LAN 대상에 `No route to host`를 반환했지만 `/usr/bin/ssh`는 같은 rock5bp 대상에 정상 연결됐다. 이 때문에 `homelab-host verify-host` 같은 운영 명령이 실행되지 않았다.

## Verification
- `python3 nix/scripts/check-migration.py`
- `python3 nix/scripts/check-topology.py`
- `nix flake check --all-systems --no-build`
- `nix build .#homelab-host --no-link`
- corrected app PATH로 rock5bp SSH smoke test
- `homelab-host verify-host rock5bp`
- receipt NAS baseline을 지정한 `verify-host`
- reviewer: actionable finding 없음