### PR TITLE
fix(nix): keep host rollback progressing after WireGuard sync failure

### DIFF
--- a/nix/scripts/check-migration.py
+++ b/nix/scripts/check-migration.py
@@ -2203,6 +2203,64 @@ def check_time_sync_waits() -> None:
 
 
 
+def check_wireguard_rollback_failure_continuation() -> None:
+    handoff = source("nix/scripts/k3s-handoff")
+    match = re.search(
+        r'(wireguard_restore_failed=false\nfor interface in \$wg_interfaces; do\n.*?^done)',
+        handoff,
+        re.DOTALL | re.MULTILINE,
+    )
+    if match is None:
+        raise SystemExit(
+            "nix/scripts/k3s-handoff: best-effort WireGuard rollback restoration missing"
+        )
+    if not re.search(
+        r'for unit in systemd-networkd\.service systemd-resolved\.service '
+        r'systemd-timesyncd\.service "\$ssh_service"; do'
+        r'.*?systemctl is-active "\$unit".*?verify_nas_manifest; fi'
+        r'.*?if test "\$wireguard_restore_failed" = true; then'
+        r'.*?rollback remains armed.*?exit 1.*?^fi'
+        r'.*?systemctl disable homelab-host-rollback\.timer',
+        handoff,
+        re.DOTALL | re.MULTILINE,
+    ):
+        raise SystemExit(
+            "nix/scripts/k3s-handoff: WireGuard restore failure must not block service recovery or disarm rollback"
+        )
+    with tempfile.TemporaryDirectory() as directory:
+        directory_path = Path(directory)
+        for command in ("ip", "networkctl"):
+            path = directory_path / command
+            path.write_text("#!/bin/sh\nexit 0\n")
+            path.chmod(0o755)
+        helper = directory_path / "sync-wireguard-runtime"
+        helper.write_text("#!/bin/sh\nexit 1\n")
+        helper.chmod(0o755)
+        result = subprocess.run(
+            ["sh"],
+            input=(
+                "set -eu\n"
+                f'PATH="{directory}:{os.environ["PATH"]}"\n'
+                f'dir="{directory}"\n'
+                "wg_interfaces=wg0\n"
+                f"{match.group(1)}\n"
+                'test "$wireguard_restore_failed" = true\n'
+                "printf 'service-recovery-continued\\n'\n"
+            ),
+            text=True,
+            capture_output=True,
+        )
+        if (
+            result.returncode
+            or result.stdout.strip() != "service-recovery-continued"
+            or "WireGuard runtime restoration failed" not in result.stderr
+        ):
+            raise SystemExit(
+                "nix/scripts/k3s-handoff: WireGuard failure aborted rollback before service recovery\n"
+                f"{result.stderr.strip()}"
+            )
+
+
 def check_firewall_restore_waits() -> None:
     handoff = source("nix/scripts/k3s-handoff")
     match = re.search(
@@ -4291,6 +4349,7 @@ check_ssh_strict_modes_guard()
 check_wireguard_handshake_probe()
 check_register_system_failure()
 check_time_sync_waits()
+check_wireguard_rollback_failure_continuation()
 check_firewall_restore_waits()
 check_cilium_restart_waits()
 check_provision_active_service_guard()

--- a/nix/scripts/k3s-handoff
+++ b/nix/scripts/k3s-handoff
@@ -481,10 +481,14 @@ sysctl --system
 systemctl restart systemd-networkd.service
 networkctl reload
 networkctl reconfigure "$default_interface"
+wireguard_restore_failed=false
 for interface in $wg_interfaces; do
   if ip link show "$interface" >/dev/null 2>&1; then
-    networkctl reconfigure "$interface"
-    "$dir/sync-wireguard-runtime" "$interface"
+    if ! networkctl reconfigure "$interface" \
+      || ! "$dir/sync-wireguard-runtime" "$interface"; then
+      echo "rollback continued after $interface WireGuard runtime restoration failed" >&2
+      wireguard_restore_failed=true
+    fi
   fi
 done
 systemctl restart systemd-timesyncd.service
@@ -644,6 +648,10 @@ if test "$package_restore_blocked" = true; then
   exit 1
 fi
 if test "$preserve_nas_state" = true; then verify_nas_manifest; fi
+if test "$wireguard_restore_failed" = true; then
+  echo "legacy services and firewall restored, but WireGuard runtime restoration failed; rollback remains armed" >&2
+  exit 1
+fi
 systemctl disable homelab-host-rollback.timer >/dev/null 2>&1 || true
 touch "$dir/restored"
 printf 'rollback completed %s\n' "$(date -u +%FT%TZ)"


### PR DESCRIPTION
## Summary

PR #295에서 추가된 `sync-wireguard-runtime` 검증이 실패하면 generated rollback script의 `set -eu` 때문에 K3s/firewall/legacy service 복구가 중단될 수 있었습니다.

- WireGuard interface reconfigure 또는 runtime sync 실패를 기록하고 나머지 rollback 복구를 계속합니다.
- systemd-networkd/resolved/timesyncd/SSH, firewall, K3s legacy unit, NAS manifest 검증이 끝날 때까지 진행합니다.
- WireGuard 복구 실패가 남아 있으면 rollback timer를 armed 상태로 유지하고 `restored` marker를 생성하지 않아 다음 실행에서 재시도합니다.
- 기존 bare-command 구현은 실패하고 수정된 구현은 계속 진행하는 behavioral migration contract를 추가합니다.

## Verification

- `bash -n nix/scripts/k3s-handoff`
- `python3 -m py_compile nix/scripts/check-migration.py`
- `python3 nix/scripts/check-migration.py`
- `git diff --check`
- `nix flake check --all-systems --no-build`
- `nix build .#checks.aarch64-darwin.migration-contracts --no-link`
- `nix build .#packages.aarch64-darwin.k3s-handoff --no-link`
- `nix build .#packages.aarch64-darwin.homelab-host --no-link`

## Review

독립 reviewer가 control-flow ordering, `set -eu`, timer/marker semantics, idempotent retry를 검토했고 blocking finding이 없었습니다.