### PR TITLE
feat(arc): deploy official cc-lb runner scale set

### DIFF
--- a/0-configure-saas/README.md
+++ b/0-configure-saas/README.md
@@ -10,6 +10,13 @@ grafana_telegram_bot_token = "<BotFather token>"
 grafana_telegram_chat_id   = "-1001234567890"
 ```
 
+ARC runners for `isac322/cc-lb` need a GitHub token with repository
+Administration read/write (fine-grained) or classic `repo` scope:
+
+```hcl
+github_actions_pat_cc_lb = "<github token>"
+```
+
 ## Get credential
 
 ### AWS

--- a/0-configure-saas/README.md
+++ b/0-configure-saas/README.md
@@ -10,11 +10,17 @@ grafana_telegram_bot_token = "<BotFather token>"
 grafana_telegram_chat_id   = "-1001234567890"
 ```
 
-ARC runners for `isac322/cc-lb` need a GitHub token with repository
-Administration read/write (fine-grained) or classic `repo` scope:
+ARC runners for `isac322/cc-lb` use a GitHub App. After creating and
+installing the app on that repository, provide:
 
 ```hcl
-github_actions_pat_cc_lb = "<github token>"
+github_app_id_arc_cc_lb              = "123456"
+github_app_installation_id_arc_cc_lb = "12345678"
+github_app_private_key_arc_cc_lb     = <<-EOT
+-----BEGIN RSA PRIVATE KEY-----
+...
+-----END RSA PRIVATE KEY-----
+EOT
 ```
 
 ## Get credential

--- a/0-configure-saas/boostrap-saas/resources-terraform-cloud.tf
+++ b/0-configure-saas/boostrap-saas/resources-terraform-cloud.tf
@@ -249,3 +249,11 @@ resource "tfe_variable" "hermes_isacmes_jay_telegram_token" {
   sensitive    = true
   workspace_id = tfe_workspace.backbone.id
 }
+
+resource "tfe_variable" "github_actions_pat_cc_lb" {
+  key          = "github_actions_pat_cc_lb"
+  value        = var.github_actions_pat_cc_lb
+  category     = "terraform"
+  sensitive    = true
+  workspace_id = tfe_workspace.backbone.id
+}

--- a/0-configure-saas/boostrap-saas/resources-terraform-cloud.tf
+++ b/0-configure-saas/boostrap-saas/resources-terraform-cloud.tf
@@ -250,9 +250,23 @@ resource "tfe_variable" "hermes_isacmes_jay_telegram_token" {
   workspace_id = tfe_workspace.backbone.id
 }
 
-resource "tfe_variable" "github_actions_pat_cc_lb" {
-  key          = "github_actions_pat_cc_lb"
-  value        = var.github_actions_pat_cc_lb
+resource "tfe_variable" "github_app_id_arc_cc_lb" {
+  key          = "github_app_id_arc_cc_lb"
+  value        = var.github_app_id_arc_cc_lb
+  category     = "terraform"
+  workspace_id = tfe_workspace.backbone.id
+}
+
+resource "tfe_variable" "github_app_installation_id_arc_cc_lb" {
+  key          = "github_app_installation_id_arc_cc_lb"
+  value        = var.github_app_installation_id_arc_cc_lb
+  category     = "terraform"
+  workspace_id = tfe_workspace.backbone.id
+}
+
+resource "tfe_variable" "github_app_private_key_arc_cc_lb" {
+  key          = "github_app_private_key_arc_cc_lb"
+  value        = var.github_app_private_key_arc_cc_lb
   category     = "terraform"
   sensitive    = true
   workspace_id = tfe_workspace.backbone.id

--- a/0-configure-saas/boostrap-saas/variables.tf
+++ b/0-configure-saas/boostrap-saas/variables.tf
@@ -147,3 +147,8 @@ variable "hermes_isacmes_jay_telegram_token" {
   type      = string
   sensitive = true
 }
+
+variable "github_actions_pat_cc_lb" {
+  type      = string
+  sensitive = true
+}

--- a/0-configure-saas/boostrap-saas/variables.tf
+++ b/0-configure-saas/boostrap-saas/variables.tf
@@ -148,7 +148,15 @@ variable "hermes_isacmes_jay_telegram_token" {
   sensitive = true
 }
 
-variable "github_actions_pat_cc_lb" {
+variable "github_app_id_arc_cc_lb" {
+  type = string
+}
+
+variable "github_app_installation_id_arc_cc_lb" {
+  type = string
+}
+
+variable "github_app_private_key_arc_cc_lb" {
   type      = string
   sensitive = true
 }

--- a/0-configure-saas/main.tf
+++ b/0-configure-saas/main.tf
@@ -38,20 +38,22 @@ provider "cloudflare" {
 module "saas" {
   source = "./boostrap-saas"
 
-  cloudflare_email                  = var.cloudflare_email
-  cloudflare_global_api_key         = var.cloudflare_global_api_key
-  cloudflare_origin_ca_key          = var.cloudflare_origin_ca_key
-  vultr_personal_access_token       = var.vultr_personal_access_token
-  postmark_account_token            = var.postmark_account_token
-  openai_api_key                    = var.openai_api_key
-  openai_proxy                      = var.openai_proxy
-  gemini_api_key                    = var.gemini_api_key
-  gcp_vertex_ai_sa_key              = var.gcp_vertex_ai_sa_key
-  grafana_telegram_bot_token        = var.grafana_telegram_bot_token
-  grafana_telegram_chat_id          = var.grafana_telegram_chat_id
-  hermes_isacmes_telegram_token     = var.hermes_isacmes_telegram_token
-  hermes_isacmes_jay_telegram_token = var.hermes_isacmes_jay_telegram_token
-  github_actions_pat_cc_lb          = var.github_actions_pat_cc_lb
+  cloudflare_email                     = var.cloudflare_email
+  cloudflare_global_api_key            = var.cloudflare_global_api_key
+  cloudflare_origin_ca_key             = var.cloudflare_origin_ca_key
+  vultr_personal_access_token          = var.vultr_personal_access_token
+  postmark_account_token               = var.postmark_account_token
+  openai_api_key                       = var.openai_api_key
+  openai_proxy                         = var.openai_proxy
+  gemini_api_key                       = var.gemini_api_key
+  gcp_vertex_ai_sa_key                 = var.gcp_vertex_ai_sa_key
+  grafana_telegram_bot_token           = var.grafana_telegram_bot_token
+  grafana_telegram_chat_id             = var.grafana_telegram_chat_id
+  hermes_isacmes_telegram_token        = var.hermes_isacmes_telegram_token
+  hermes_isacmes_jay_telegram_token    = var.hermes_isacmes_jay_telegram_token
+  github_app_id_arc_cc_lb              = var.github_app_id_arc_cc_lb
+  github_app_installation_id_arc_cc_lb = var.github_app_installation_id_arc_cc_lb
+  github_app_private_key_arc_cc_lb     = var.github_app_private_key_arc_cc_lb
 
   aws_admin_account_id  = 825808295984
   aws_admin_family_name = "Yoo"

--- a/0-configure-saas/main.tf
+++ b/0-configure-saas/main.tf
@@ -51,6 +51,7 @@ module "saas" {
   grafana_telegram_chat_id          = var.grafana_telegram_chat_id
   hermes_isacmes_telegram_token     = var.hermes_isacmes_telegram_token
   hermes_isacmes_jay_telegram_token = var.hermes_isacmes_jay_telegram_token
+  github_actions_pat_cc_lb          = var.github_actions_pat_cc_lb
 
   aws_admin_account_id  = 825808295984
   aws_admin_family_name = "Yoo"

--- a/0-configure-saas/variables.tf
+++ b/0-configure-saas/variables.tf
@@ -67,3 +67,8 @@ variable "hermes_isacmes_jay_telegram_token" {
   type      = string
   sensitive = true
 }
+
+variable "github_actions_pat_cc_lb" {
+  type      = string
+  sensitive = true
+}

--- a/0-configure-saas/variables.tf
+++ b/0-configure-saas/variables.tf
@@ -68,7 +68,15 @@ variable "hermes_isacmes_jay_telegram_token" {
   sensitive = true
 }
 
-variable "github_actions_pat_cc_lb" {
+variable "github_app_id_arc_cc_lb" {
+  type = string
+}
+
+variable "github_app_installation_id_arc_cc_lb" {
+  type = string
+}
+
+variable "github_app_private_key_arc_cc_lb" {
   type      = string
   sensitive = true
 }

--- a/1-provision/env/backbone/main.tf
+++ b/1-provision/env/backbone/main.tf
@@ -63,6 +63,7 @@ module "dns_secrets" {
   grafana_telegram_chat_id                    = var.grafana_telegram_chat_id
   hermes_isacmes_telegram_token               = var.hermes_isacmes_telegram_token
   hermes_isacmes_jay_telegram_token           = var.hermes_isacmes_jay_telegram_token
+  github_actions_pat_cc_lb                    = var.github_actions_pat_cc_lb
 
   providers = {
     aws        = aws

--- a/1-provision/env/backbone/main.tf
+++ b/1-provision/env/backbone/main.tf
@@ -63,7 +63,9 @@ module "dns_secrets" {
   grafana_telegram_chat_id                    = var.grafana_telegram_chat_id
   hermes_isacmes_telegram_token               = var.hermes_isacmes_telegram_token
   hermes_isacmes_jay_telegram_token           = var.hermes_isacmes_jay_telegram_token
-  github_actions_pat_cc_lb                    = var.github_actions_pat_cc_lb
+  github_app_id_arc_cc_lb                     = var.github_app_id_arc_cc_lb
+  github_app_installation_id_arc_cc_lb        = var.github_app_installation_id_arc_cc_lb
+  github_app_private_key_arc_cc_lb            = var.github_app_private_key_arc_cc_lb
 
   providers = {
     aws        = aws

--- a/1-provision/env/backbone/vars.tf
+++ b/1-provision/env/backbone/vars.tf
@@ -76,7 +76,17 @@ variable "hermes_isacmes_jay_telegram_token" {
   sensitive = true
 }
 
-variable "github_actions_pat_cc_lb" {
+variable "github_app_id_arc_cc_lb" {
+  type    = string
+  default = null
+}
+
+variable "github_app_installation_id_arc_cc_lb" {
+  type    = string
+  default = null
+}
+
+variable "github_app_private_key_arc_cc_lb" {
   type      = string
   sensitive = true
   default   = null

--- a/1-provision/env/backbone/vars.tf
+++ b/1-provision/env/backbone/vars.tf
@@ -75,3 +75,9 @@ variable "hermes_isacmes_jay_telegram_token" {
   type      = string
   sensitive = true
 }
+
+variable "github_actions_pat_cc_lb" {
+  type      = string
+  sensitive = true
+  default   = null
+}

--- a/1-provision/modules/dns-secrets/res-secrets.tf
+++ b/1-provision/modules/dns-secrets/res-secrets.tf
@@ -125,6 +125,14 @@ resource "aws_ssm_parameter" "hermes_isacmes_jay_telegram_token" {
   value       = var.hermes_isacmes_jay_telegram_token
 }
 
+resource "aws_ssm_parameter" "github_actions_pat_cc_lb" {
+  count       = var.github_actions_pat_cc_lb == null ? 0 : 1
+  name        = "/homelab/cluster/${var.k8s_cluster_name}/token/github/arc-cc-lb"
+  description = "GitHub token for ARC runners registered to isac322/cc-lb"
+  type        = "SecureString"
+  value       = var.github_actions_pat_cc_lb
+}
+
 # --- External Secrets IAM ---
 
 resource "aws_iam_user" "external_secrets" {
@@ -158,6 +166,7 @@ data "aws_iam_policy_document" "secret_read" {
       var.grafana_telegram_chat_id == null ? [] : [aws_ssm_parameter.grafana_telegram_chat_id[0].arn],
       var.hermes_isacmes_telegram_token == null ? [] : [aws_ssm_parameter.hermes_isacmes_telegram_token[0].arn],
       var.hermes_isacmes_jay_telegram_token == null ? [] : [aws_ssm_parameter.hermes_isacmes_jay_telegram_token[0].arn],
+      var.github_actions_pat_cc_lb == null ? [] : [aws_ssm_parameter.github_actions_pat_cc_lb[0].arn],
     )
   }
 }

--- a/1-provision/modules/dns-secrets/res-secrets.tf
+++ b/1-provision/modules/dns-secrets/res-secrets.tf
@@ -125,12 +125,28 @@ resource "aws_ssm_parameter" "hermes_isacmes_jay_telegram_token" {
   value       = var.hermes_isacmes_jay_telegram_token
 }
 
-resource "aws_ssm_parameter" "github_actions_pat_cc_lb" {
-  count       = var.github_actions_pat_cc_lb == null ? 0 : 1
-  name        = "/homelab/cluster/${var.k8s_cluster_name}/token/github/arc-cc-lb"
-  description = "GitHub token for ARC runners registered to isac322/cc-lb"
+resource "aws_ssm_parameter" "github_app_id_arc_cc_lb" {
+  count       = var.github_app_id_arc_cc_lb == null ? 0 : 1
+  name        = "/homelab/cluster/${var.k8s_cluster_name}/github-app/arc-cc-lb/id"
+  description = "GitHub App id for ARC runners on isac322/cc-lb"
+  type        = "String"
+  value       = var.github_app_id_arc_cc_lb
+}
+
+resource "aws_ssm_parameter" "github_app_installation_id_arc_cc_lb" {
+  count       = var.github_app_installation_id_arc_cc_lb == null ? 0 : 1
+  name        = "/homelab/cluster/${var.k8s_cluster_name}/github-app/arc-cc-lb/installation-id"
+  description = "GitHub App installation id for ARC runners on isac322/cc-lb"
+  type        = "String"
+  value       = var.github_app_installation_id_arc_cc_lb
+}
+
+resource "aws_ssm_parameter" "github_app_private_key_arc_cc_lb" {
+  count       = var.github_app_private_key_arc_cc_lb == null ? 0 : 1
+  name        = "/homelab/cluster/${var.k8s_cluster_name}/github-app/arc-cc-lb/private-key"
+  description = "GitHub App private key for ARC runners on isac322/cc-lb"
   type        = "SecureString"
-  value       = var.github_actions_pat_cc_lb
+  value       = var.github_app_private_key_arc_cc_lb
 }
 
 # --- External Secrets IAM ---
@@ -166,7 +182,9 @@ data "aws_iam_policy_document" "secret_read" {
       var.grafana_telegram_chat_id == null ? [] : [aws_ssm_parameter.grafana_telegram_chat_id[0].arn],
       var.hermes_isacmes_telegram_token == null ? [] : [aws_ssm_parameter.hermes_isacmes_telegram_token[0].arn],
       var.hermes_isacmes_jay_telegram_token == null ? [] : [aws_ssm_parameter.hermes_isacmes_jay_telegram_token[0].arn],
-      var.github_actions_pat_cc_lb == null ? [] : [aws_ssm_parameter.github_actions_pat_cc_lb[0].arn],
+      var.github_app_id_arc_cc_lb == null ? [] : [aws_ssm_parameter.github_app_id_arc_cc_lb[0].arn],
+      var.github_app_installation_id_arc_cc_lb == null ? [] : [aws_ssm_parameter.github_app_installation_id_arc_cc_lb[0].arn],
+      var.github_app_private_key_arc_cc_lb == null ? [] : [aws_ssm_parameter.github_app_private_key_arc_cc_lb[0].arn],
     )
   }
 }

--- a/1-provision/modules/dns-secrets/vars.tf
+++ b/1-provision/modules/dns-secrets/vars.tf
@@ -79,3 +79,9 @@ variable "hermes_isacmes_jay_telegram_token" {
   sensitive = true
   default   = null
 }
+
+variable "github_actions_pat_cc_lb" {
+  type      = string
+  sensitive = true
+  default   = null
+}

--- a/1-provision/modules/dns-secrets/vars.tf
+++ b/1-provision/modules/dns-secrets/vars.tf
@@ -80,7 +80,17 @@ variable "hermes_isacmes_jay_telegram_token" {
   default   = null
 }
 
-variable "github_actions_pat_cc_lb" {
+variable "github_app_id_arc_cc_lb" {
+  type    = string
+  default = null
+}
+
+variable "github_app_installation_id_arc_cc_lb" {
+  type    = string
+  default = null
+}
+
+variable "github_app_private_key_arc_cc_lb" {
   type      = string
   sensitive = true
   default   = null

--- a/apps/objects/actions-runner-controller/external-secret.yaml
+++ b/apps/objects/actions-runner-controller/external-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-config
+  namespace: arc-runners
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: cluster-secrets
+    kind: ClusterSecretStore
+  target:
+    name: github-config
+    creationPolicy: Owner
+  data:
+    - secretKey: github_token
+      remoteRef:
+        key: /homelab/cluster/backbone/token/github/arc-cc-lb

--- a/apps/objects/actions-runner-controller/external-secret.yaml
+++ b/apps/objects/actions-runner-controller/external-secret.yaml
@@ -12,6 +12,12 @@ spec:
     name: github-config
     creationPolicy: Owner
   data:
-    - secretKey: github_token
+    - secretKey: github_app_id
       remoteRef:
-        key: /homelab/cluster/backbone/token/github/arc-cc-lb
+        key: /homelab/cluster/backbone/github-app/arc-cc-lb/id
+    - secretKey: github_app_installation_id
+      remoteRef:
+        key: /homelab/cluster/backbone/github-app/arc-cc-lb/installation-id
+    - secretKey: github_app_private_key
+      remoteRef:
+        key: /homelab/cluster/backbone/github-app/arc-cc-lb/private-key

--- a/argocd/appprojects/github-actions-runner.yaml
+++ b/argocd/appprojects/github-actions-runner.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: github-actions-runner
+spec:
+  description: Actions Runner Controller and cc-lb runner scale set
+  sourceRepos:
+    - https://github.com/isac322/homelab.git
+    - ghcr.io/actions/actions-runner-controller-charts
+  destinations:
+    - namespace: arc-systems
+      name: backbone
+    - namespace: arc-runners
+      name: backbone
+  clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'

--- a/argocd/apps/actions-runner-controller.yaml
+++ b/argocd/apps/actions-runner-controller.yaml
@@ -1,0 +1,107 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: actions-runner-controller
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: backbone
+    namespace: arc-systems
+  project: github-actions-runner
+  sources:
+    - repoURL: https://github.com/isac322/homelab.git
+      targetRevision: HEAD
+      ref: homelab
+    - chart: gha-runner-scale-set-controller
+      helm:
+        releaseName: arc
+        valueFiles:
+          - values.yaml
+          - $homelab/values/gha-runner-scale-set-controller/backbone.yaml
+      repoURL: ghcr.io/actions/actions-runner-controller-charts
+      targetRevision: 0.14.2
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
+      limit: 100
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: actions-runner-controller-objects
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: backbone
+    namespace: arc-runners
+  project: github-actions-runner
+  source:
+    path: apps/objects/actions-runner-controller
+    repoURL: https://github.com/isac322/homelab.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
+      limit: 100
+    syncOptions:
+      - CreateNamespace=true
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - .spec.data[].remoteRef.conversionStrategy
+        - .spec.data[].remoteRef.decodingStrategy
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arc-cc-lb
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: backbone
+    namespace: arc-runners
+  project: github-actions-runner
+  sources:
+    - repoURL: https://github.com/isac322/homelab.git
+      targetRevision: HEAD
+      ref: homelab
+    - chart: gha-runner-scale-set
+      helm:
+        releaseName: cc-lb
+        valueFiles:
+          - values.yaml
+          - $homelab/values/gha-runner-scale-set/cc-lb.yaml
+      repoURL: ghcr.io/actions/actions-runner-controller-charts
+      targetRevision: 0.14.2
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
+      limit: 100
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/values/gha-runner-scale-set-controller/backbone.yaml
+++ b/values/gha-runner-scale-set-controller/backbone.yaml
@@ -1,0 +1,16 @@
+fullnameOverride: arc-gha-rs-controller
+
+image:
+  repository: ghcr.io/actions/gha-runner-scale-set-controller
+  tag: 0.14.2@sha256:1b4c7f62e971ab259a4b8798e48e2adaad4af747f45990f474ea5feefa03531d
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: arc-gha-rs-controller
+
+flags:
+  logLevel: info
+  logFormat: text
+  excludeLabelPropagationPrefixes:
+    - argocd.argoproj.io/instance

--- a/values/gha-runner-scale-set/cc-lb.yaml
+++ b/values/gha-runner-scale-set/cc-lb.yaml
@@ -1,0 +1,73 @@
+githubConfigUrl: https://github.com/isac322/cc-lb
+githubConfigSecret: github-config
+runnerScaleSetName: oracle4-cc-lb
+
+minRunners: 0
+maxRunners: 4
+
+controllerServiceAccount:
+  namespace: arc-systems
+  name: arc-gha-rs-controller
+
+# Official ARC runner image with chart dind sidecar. containerMode is left
+# empty so the injected latest tags can be replaced with digest pins.
+template:
+  spec:
+    initContainers:
+      - name: init-dind-externals
+        image: ghcr.io/actions/actions-runner:2.337.0@sha256:e5496277be5d09bc968b3d64911b74e219ac4a3f2edce956a3ecf9271bea1ef4
+        command: ["cp", "-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+        volumeMounts:
+          - name: dind-externals
+            mountPath: /home/runner/tmpDir
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:2.337.0@sha256:e5496277be5d09bc968b3d64911b74e219ac4a3f2edce956a3ecf9271bea1ef4
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: DOCKER_HOST
+            value: unix:///var/run/docker.sock
+          - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+            value: "120"
+        resources:
+          requests:
+            cpu: "1"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: dind-sock
+            mountPath: /var/run
+      - name: dind
+        image: docker:28-dind@sha256:2a232a42256f70d78e3cc5d2b5d6b3276710a0de0596c145f627ecfae90282ac
+        args:
+          - dockerd
+          - --host=unix:///var/run/docker.sock
+          - --group=$(DOCKER_GROUP_GID)
+        env:
+          - name: DOCKER_GROUP_GID
+            value: "123"
+        securityContext:
+          privileged: true
+        restartPolicy: Always
+        startupProbe:
+          exec:
+            command:
+              - docker
+              - info
+          initialDelaySeconds: 0
+          failureThreshold: 24
+          periodSeconds: 5
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: dind-sock
+            mountPath: /var/run
+          - name: dind-externals
+            mountPath: /home/runner/externals
+    volumes:
+      - name: work
+        emptyDir: {}
+      - name: dind-sock
+        emptyDir: {}
+      - name: dind-externals
+        emptyDir: {}

--- a/values/gha-runner-scale-set/cc-lb.yaml
+++ b/values/gha-runner-scale-set/cc-lb.yaml
@@ -48,7 +48,6 @@ template:
             value: "123"
         securityContext:
           privileged: true
-        restartPolicy: Always
         startupProbe:
           exec:
             command:


### PR DESCRIPTION
## Summary

`isac322/cc-lb`용 ARC를 backbone에 배포한다. 최신 GitHub-supported chart `0.14.2`와 공식 `ghcr.io/actions/actions-runner` 이미지를 사용한다.

## Changes

- controller: `gha-runner-scale-set-controller` 0.14.2, image digest pin
- scale set: `isac322/cc-lb` repo 등록, `runs-on: oracle4-cc-lb` 유지
- runner image: `ghcr.io/actions/actions-runner:2.337.0@sha256:e5496277be5d09bc968b3d64911b74e219ac4a3f2edce956a3ecf9271bea1ef4`
- Docker jobs를 위해 chart dind sidecar를 공식 템플릿 그대로 쓰되 `docker:28-dind` digest pin
- GitHub 인증은 SSM `/homelab/cluster/backbone/token/github/arc-cc-lb` → ExternalSecret `github-config`
- PAT는 필수가 아님. GitHub App이면 secret 키를 `github_app_id` / `github_app_installation_id` / `github_app_private_key`로 바꾸면 된다.

## Not included

oracle4 커스텀 스택(자체 runner 이미지, garage sccache, registry-proxy, hostPath rust/cargo cache)은 넣지 않았다. 공식 이미지만 요청됐기 때문이다.

## Before this goes live

`0-configure-saas` `.tfvars`에 `github_actions_pat_cc_lb`를 넣고 apply해야 ExternalSecret이 채워진다. fine-grained PAT는 `isac322/cc-lb` Administration read/write, classic PAT는 `repo` scope. GitHub App을 쓰면 이 경로를 App 자격 증명 세 개로 바꾸면 된다.

## Validation

- `terraform fmt -check`
- `helm template` for controller and scale set; official image pins present, `latest` absent
