### PR TITLE
chore(terraform): import GitHub App SSM parameters for ARC

### DIFF
--- a/0-configure-saas/imports.tf
+++ b/0-configure-saas/imports.tf
@@ -1,0 +1,14 @@
+import {
+  to = module.saas.tfe_variable.github_app_id_arc_cc_lb
+  id = "bhyoo/homelab-backbone/github_app_id_arc_cc_lb/terraform"
+}
+
+import {
+  to = module.saas.tfe_variable.github_app_installation_id_arc_cc_lb
+  id = "bhyoo/homelab-backbone/github_app_installation_id_arc_cc_lb/terraform"
+}
+
+import {
+  to = module.saas.tfe_variable.github_app_private_key_arc_cc_lb
+  id = "bhyoo/homelab-backbone/github_app_private_key_arc_cc_lb/terraform"
+}

--- a/1-provision/env/backbone/imports.tf
+++ b/1-provision/env/backbone/imports.tf
@@ -12,3 +12,18 @@ import {
   to = module.dns_secrets.aws_ssm_parameter.hermes_isacmes_jay_telegram_token[0]
   id = "/homelab/cluster/backbone/token/telegram/isacmes-jay"
 }
+
+import {
+  to = module.dns_secrets.aws_ssm_parameter.github_app_id_arc_cc_lb[0]
+  id = "/homelab/cluster/backbone/github-app/arc-cc-lb/id"
+}
+
+import {
+  to = module.dns_secrets.aws_ssm_parameter.github_app_installation_id_arc_cc_lb[0]
+  id = "/homelab/cluster/backbone/github-app/arc-cc-lb/installation-id"
+}
+
+import {
+  to = module.dns_secrets.aws_ssm_parameter.github_app_private_key_arc_cc_lb[0]
+  id = "/homelab/cluster/backbone/github-app/arc-cc-lb/private-key"
+}


### PR DESCRIPTION
## Summary

Adopt the GitHub App credentials already in SSM/TFC into Terraform so later applies do not recreate them.

## Already applied

- TFC workspace `homelab-backbone` now has `github_app_id_arc_cc_lb`, `github_app_installation_id_arc_cc_lb`, `github_app_private_key_arc_cc_lb` (sensitive).
- `terraform apply` on `1-provision/env/backbone`: 3 imported, 0 added, 4 changed, 0 destroyed.

## This PR

- Import blocks for the three SSM parameters (same pattern as Hermes tokens).
- Import blocks for the three TFC variables so the next `0-configure-saas` apply adopts them instead of creating duplicates.

GitHub App *registration* is still not Terraform-managed. GitHub has no public CRUD API for Apps besides the one-shot manifest flow.