### PR TITLE
feat(arc): pin runner image with gcc cc and hadolint

### DIFF
--- a/values/gha-runner-scale-set/cc-lb-1.yaml
+++ b/values/gha-runner-scale-set/cc-lb-1.yaml
@@ -25,7 +25,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-eadffd458017@sha256:628482521262ff2d2ad2f5b7ba6475145773acb5a8bef0275ae7e9bbf33f113b
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS

--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -25,7 +25,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-eadffd458017@sha256:628482521262ff2d2ad2f5b7ba6475145773acb5a8bef0275ae7e9bbf33f113b
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -25,7 +25,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-eadffd458017@sha256:628482521262ff2d2ad2f5b7ba6475145773acb5a8bef0275ae7e9bbf33f113b
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS

--- a/values/gha-runner-scale-set/cc-lb-500m.yaml
+++ b/values/gha-runner-scale-set/cc-lb-500m.yaml
@@ -25,7 +25,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-eadffd458017@sha256:628482521262ff2d2ad2f5b7ba6475145773acb5a8bef0275ae7e9bbf33f113b
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS


### PR DESCRIPTION
## Summary
Pin ARC scale sets to `2.337.0-cclb-91f8035a0c5f` so default `cc` is gcc (jemalloc configure) and hadolint/rg ship on the runner.