### PR TITLE
feat(arc): set CPU and memory requests and limits on cc-lb runners

### DIFF
--- a/values/gha-runner-scale-set/cc-lb-1.yaml
+++ b/values/gha-runner-scale-set/cc-lb-1.yaml
@@ -47,3 +47,7 @@ template:
         resources:
           requests:
             cpu: 1
+            memory: 2Gi
+          limits:
+            cpu: 1
+            memory: 2Gi

--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -47,3 +47,7 @@ template:
         resources:
           requests:
             cpu: 2
+            memory: 4Gi
+          limits:
+            cpu: 2
+            memory: 4Gi

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -47,3 +47,7 @@ template:
         resources:
           requests:
             cpu: 3
+            memory: 8Gi
+          limits:
+            cpu: 3
+            memory: 8Gi

--- a/values/gha-runner-scale-set/cc-lb-500m.yaml
+++ b/values/gha-runner-scale-set/cc-lb-500m.yaml
@@ -47,3 +47,7 @@ template:
         resources:
           requests:
             cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 1Gi


### PR DESCRIPTION
## Summary
All four `cc-lb-*` runner scale sets now declare CPU and memory **requests and limits** (Guaranteed QoS).

| scale set | CPU | memory |
| --- | --- | --- |
| cc-lb-500m | 500m | 1Gi |
| cc-lb-1 | 1 | 2Gi |
| cc-lb-2 | 2 | 4Gi |
| cc-lb-4 | 3 | 8Gi |

CPU matches the existing request (cc-lb-4 stays at 3 so k3s keeps a core). Memory follows observed job weight so light fmt/promtool pods cannot balloon and clippy/nextest still have headroom under the previous ~3.5 Gi p95.
