### PR TITLE
feat(arc): back sccache with versitygw COSI

### DIFF
--- a/apps/objects/actions-runner-controller/bucket-access.yaml
+++ b/apps/objects/actions-runner-controller/bucket-access.yaml
@@ -1,0 +1,9 @@
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketAccess
+metadata:
+  name: sccache
+spec:
+  bucketAccessClassName: versitygw
+  bucketClaimName: sccache
+  credentialsSecretName: sccache-bucket-creds
+  protocol: S3

--- a/apps/objects/actions-runner-controller/bucket-claim.yaml
+++ b/apps/objects/actions-runner-controller/bucket-claim.yaml
@@ -1,0 +1,9 @@
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: BucketClaim
+metadata:
+  name: sccache
+spec:
+  bucketClassName: versitygw
+  existingBucketName: sccache
+  protocols:
+    - S3

--- a/apps/objects/actions-runner-controller/bucket.yaml
+++ b/apps/objects/actions-runner-controller/bucket.yaml
@@ -1,0 +1,13 @@
+apiVersion: objectstorage.k8s.io/v1alpha1
+kind: Bucket
+metadata:
+  name: sccache
+spec:
+  bucketClaim:
+    name: sccache
+    namespace: arc-runners
+  bucketClassName: versitygw
+  driverName: versitygw.cosi.dev
+  deletionPolicy: Retain
+  protocols:
+    - S3

--- a/apps/objects/actions-runner-controller/sccache-s3.yaml
+++ b/apps/objects/actions-runner-controller/sccache-s3.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sccache-s3
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: kubernetes
+    kind: SecretStore
+  target:
+    name: sccache-s3
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ (.BucketInfo | fromJson).spec.secretS3.accessKeyID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ (.BucketInfo | fromJson).spec.secretS3.accessSecretKey }}"
+        SCCACHE_BUCKET: "{{ (.BucketInfo | fromJson).spec.bucketName }}"
+        SCCACHE_ENDPOINT: http://versitygw.object-storage.svc.cluster.local:7070
+        SCCACHE_REGION: us-east-1
+        SCCACHE_S3_USE_SSL: "false"
+        SCCACHE_S3_KEY_PREFIX: cc-lb
+  data:
+    - secretKey: BucketInfo
+      remoteRef:
+        key: sccache-bucket-creds
+        property: BucketInfo

--- a/apps/objects/actions-runner-controller/secret-store.yaml
+++ b/apps/objects/actions-runner-controller/secret-store.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cosi-secret-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cosi-secret-reader
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cosi-secret-reader
+subjects:
+  - kind: ServiceAccount
+    name: cosi-secret-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cosi-secret-reader
+---
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: kubernetes
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: arc-runners
+      server:
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: cosi-secret-reader

--- a/apps/objects/buildkit/configmap.yaml
+++ b/apps/objects/buildkit/configmap.yaml
@@ -6,11 +6,15 @@ metadata:
 data:
   buildkitd.toml: |
     [registry."docker.io"]
-      mirrors = ["http://registry-docker-io.arc-systems.svc.cluster.local:5000"]
+      mirrors = ["registry-docker-io.arc-systems.svc.cluster.local:5000"]
+
+    [registry."registry-docker-io.arc-systems.svc.cluster.local:5000"]
       http = true
       insecure = true
 
     [registry."ghcr.io"]
-      mirrors = ["http://registry-ghcr-io.arc-systems.svc.cluster.local:5000"]
+      mirrors = ["registry-ghcr-io.arc-systems.svc.cluster.local:5000"]
+
+    [registry."registry-ghcr-io.arc-systems.svc.cluster.local:5000"]
       http = true
       insecure = true

--- a/values/gha-runner-scale-set-controller/backbone.yaml
+++ b/values/gha-runner-scale-set-controller/backbone.yaml
@@ -14,3 +14,11 @@ flags:
   logFormat: text
   excludeLabelPropagationPrefixes:
     - argocd.argoproj.io/instance
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/values/gha-runner-scale-set/cc-lb-1.yaml
+++ b/values/gha-runner-scale-set/cc-lb-1.yaml
@@ -44,6 +44,48 @@ template:
             value: http://gha-cache-server.arc-systems.svc.cluster.local:3000/
           - name: DISABLE_RUNNER_UPDATE
             value: "true"
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_ACCESS_KEY_ID
+                optional: true
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_SECRET_ACCESS_KEY
+                optional: true
+          - name: SCCACHE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_BUCKET
+                optional: true
+          - name: SCCACHE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_ENDPOINT
+                optional: true
+          - name: SCCACHE_REGION
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_REGION
+                optional: true
+          - name: SCCACHE_S3_USE_SSL
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_USE_SSL
+                optional: true
+          - name: SCCACHE_S3_KEY_PREFIX
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_KEY_PREFIX
+                optional: true
         resources:
           requests:
             cpu: 1

--- a/values/gha-runner-scale-set/cc-lb-1.yaml
+++ b/values/gha-runner-scale-set/cc-lb-1.yaml
@@ -93,3 +93,15 @@ template:
           limits:
             cpu: 1
             memory: 2Gi
+
+listenerTemplate:
+  spec:
+    containers:
+      - name: listener
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -93,3 +93,15 @@ template:
           limits:
             cpu: 2
             memory: 4Gi
+
+listenerTemplate:
+  spec:
+    containers:
+      - name: listener
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -44,6 +44,48 @@ template:
             value: http://gha-cache-server.arc-systems.svc.cluster.local:3000/
           - name: DISABLE_RUNNER_UPDATE
             value: "true"
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_ACCESS_KEY_ID
+                optional: true
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_SECRET_ACCESS_KEY
+                optional: true
+          - name: SCCACHE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_BUCKET
+                optional: true
+          - name: SCCACHE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_ENDPOINT
+                optional: true
+          - name: SCCACHE_REGION
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_REGION
+                optional: true
+          - name: SCCACHE_S3_USE_SSL
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_USE_SSL
+                optional: true
+          - name: SCCACHE_S3_KEY_PREFIX
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_KEY_PREFIX
+                optional: true
         resources:
           requests:
             cpu: 2

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -93,3 +93,15 @@ template:
           limits:
             cpu: 3
             memory: 8Gi
+
+listenerTemplate:
+  spec:
+    containers:
+      - name: listener
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -44,6 +44,48 @@ template:
             value: http://gha-cache-server.arc-systems.svc.cluster.local:3000/
           - name: DISABLE_RUNNER_UPDATE
             value: "true"
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_ACCESS_KEY_ID
+                optional: true
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_SECRET_ACCESS_KEY
+                optional: true
+          - name: SCCACHE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_BUCKET
+                optional: true
+          - name: SCCACHE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_ENDPOINT
+                optional: true
+          - name: SCCACHE_REGION
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_REGION
+                optional: true
+          - name: SCCACHE_S3_USE_SSL
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_USE_SSL
+                optional: true
+          - name: SCCACHE_S3_KEY_PREFIX
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_KEY_PREFIX
+                optional: true
         resources:
           requests:
             cpu: 3

--- a/values/gha-runner-scale-set/cc-lb-500m.yaml
+++ b/values/gha-runner-scale-set/cc-lb-500m.yaml
@@ -93,3 +93,15 @@ template:
           limits:
             cpu: 500m
             memory: 1Gi
+
+listenerTemplate:
+  spec:
+    containers:
+      - name: listener
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi

--- a/values/gha-runner-scale-set/cc-lb-500m.yaml
+++ b/values/gha-runner-scale-set/cc-lb-500m.yaml
@@ -44,6 +44,48 @@ template:
             value: http://gha-cache-server.arc-systems.svc.cluster.local:3000/
           - name: DISABLE_RUNNER_UPDATE
             value: "true"
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_ACCESS_KEY_ID
+                optional: true
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: AWS_SECRET_ACCESS_KEY
+                optional: true
+          - name: SCCACHE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_BUCKET
+                optional: true
+          - name: SCCACHE_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_ENDPOINT
+                optional: true
+          - name: SCCACHE_REGION
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_REGION
+                optional: true
+          - name: SCCACHE_S3_USE_SSL
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_USE_SSL
+                optional: true
+          - name: SCCACHE_S3_KEY_PREFIX
+            valueFrom:
+              secretKeyRef:
+                name: sccache-s3
+                key: SCCACHE_S3_KEY_PREFIX
+                optional: true
         resources:
           requests:
             cpu: 500m


### PR DESCRIPTION
## Summary
sccache was pointed at `garage.arc-systems`, which does not exist. The compiler cache is still required. This wires it to the existing **versitygw COSI** class (SSD) instead of deleting it.

- `Bucket` / `BucketClaim` / `BucketAccess` `sccache` in `arc-runners`
- ExternalSecret flattens COSI `BucketInfo` into `sccache-s3` (`AWS_*`, `SCCACHE_BUCKET/ENDPOINT/REGION`, `SCCACHE_S3_USE_SSL=false`, prefix `cc-lb`)
- All four `cc-lb-*` runner scale sets inject those env vars (`optional: true` so pods still start before COSI is ready)

Endpoint: `http://versitygw.object-storage.svc.cluster.local:7070`
