### PR TITLE
fix(buildkit): privileged v0.33.0 with GC, probes, and cgroupns

### DIFF
--- a/apps/objects/buildkit/configmap.yaml
+++ b/apps/objects/buildkit/configmap.yaml
@@ -18,3 +18,39 @@ data:
     [registry."registry-ghcr-io.arc-systems.svc.cluster.local:5000"]
       http = true
       insecure = true
+  entrypoint.sh: |
+    #!/bin/sh
+    # Privileged BuildKit uses the host cgroup namespace, so runc workers land
+    # in /sys/fs/cgroup/buildkit on the node instead of the pod's kubepods
+    # slice. kubelet then reports 0 CPU/memory and cpu.max/memory.max never
+    # apply. Reparent into the CRI container cgroup before exec.
+    set -eu
+    cfg=/etc/buildkit/buildkitd.toml
+    if [ ! -d /sys/fs/cgroup/kubepods.slice ]; then
+      exec buildkitd --config "$cfg" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234
+    fi
+    uid=$(echo "${POD_UID}" | tr '-' '_')
+    slice=$(find /sys/fs/cgroup/kubepods.slice \
+      \( -name "kubepods-burstable-pod${uid}.slice" \
+      -o -name "kubepods-besteffort-pod${uid}.slice" \
+      -o -name "kubepods-pod${uid}.slice" \) -type d | head -n 1)
+    if [ -z "${slice}" ]; then
+      exec buildkitd --config "$cfg" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234
+    fi
+    scope=$(find "${slice}" -maxdepth 1 -type d -name 'cri-containerd-*.scope' | head -n 1)
+    if [ -z "${scope}" ]; then
+      exec buildkitd --config "$cfg" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234
+    fi
+    initcg="${scope}/init"
+    mkdir -p "${initcg}"
+    echo $$ > "${initcg}/cgroup.procs"
+    if [ ! -s "${scope}/cgroup.subtree_control" ]; then
+      echo '+cpu +memory +io +pids' > "${scope}/cgroup.subtree_control" || true
+    fi
+    parent=${scope#/sys/fs/cgroup}
+    runtime_cfg=/tmp/buildkitd.toml
+    {
+      cat "$cfg"
+      printf '\n[worker.oci]\n  defaultCgroupParent = "%s"\n' "${parent}"
+    } > "${runtime_cfg}"
+    exec buildkitd --config "${runtime_cfg}" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234

--- a/apps/objects/buildkit/configmap.yaml
+++ b/apps/objects/buildkit/configmap.yaml
@@ -5,6 +5,34 @@ metadata:
   namespace: arc-systems
 data:
   buildkitd.toml: |
+    root = "/var/lib/buildkit"
+
+    [grpc]
+      address = ["unix:///run/buildkit/buildkitd.sock", "tcp://0.0.0.0:1234"]
+      debugAddress = "0.0.0.0:6060"
+
+    [history]
+      maxAge = 172800
+      maxEntries = 50
+
+    [worker.oci]
+      enabled = true
+      gc = true
+      reservedSpace = "10GB"
+      maxUsedSpace = "45GB"
+      minFreeSpace = "5GB"
+      max-parallelism = 4
+
+      [[worker.oci.gcpolicy]]
+        keepDuration = "48h"
+        reservedSpace = "100MB"
+        filters = ["type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+
+      [[worker.oci.gcpolicy]]
+        all = true
+        reservedSpace = "10GB"
+        maxUsedSpace = "45GB"
+
     [registry."docker.io"]
       mirrors = ["registry-docker-io.arc-systems.svc.cluster.local:5000"]
 
@@ -18,39 +46,3 @@ data:
     [registry."registry-ghcr-io.arc-systems.svc.cluster.local:5000"]
       http = true
       insecure = true
-  entrypoint.sh: |
-    #!/bin/sh
-    # Privileged BuildKit uses the host cgroup namespace, so runc workers land
-    # in /sys/fs/cgroup/buildkit on the node instead of the pod's kubepods
-    # slice. kubelet then reports 0 CPU/memory and cpu.max/memory.max never
-    # apply. Reparent into the CRI container cgroup before exec.
-    set -eu
-    cfg=/etc/buildkit/buildkitd.toml
-    if [ ! -d /sys/fs/cgroup/kubepods.slice ]; then
-      exec buildkitd --config "$cfg" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234
-    fi
-    uid=$(echo "${POD_UID}" | tr '-' '_')
-    slice=$(find /sys/fs/cgroup/kubepods.slice \
-      \( -name "kubepods-burstable-pod${uid}.slice" \
-      -o -name "kubepods-besteffort-pod${uid}.slice" \
-      -o -name "kubepods-pod${uid}.slice" \) -type d | head -n 1)
-    if [ -z "${slice}" ]; then
-      exec buildkitd --config "$cfg" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234
-    fi
-    scope=$(find "${slice}" -maxdepth 1 -type d -name 'cri-containerd-*.scope' | head -n 1)
-    if [ -z "${scope}" ]; then
-      exec buildkitd --config "$cfg" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234
-    fi
-    initcg="${scope}/init"
-    mkdir -p "${initcg}"
-    echo $$ > "${initcg}/cgroup.procs"
-    if [ ! -s "${scope}/cgroup.subtree_control" ]; then
-      echo '+cpu +memory +io +pids' > "${scope}/cgroup.subtree_control" || true
-    fi
-    parent=${scope#/sys/fs/cgroup}
-    runtime_cfg=/tmp/buildkitd.toml
-    {
-      cat "$cfg"
-      printf '\n[worker.oci]\n  defaultCgroupParent = "%s"\n' "${parent}"
-    } > "${runtime_cfg}"
-    exec buildkitd --config "${runtime_cfg}" --addr unix:///run/buildkit/buildkitd.sock --addr tcp://0.0.0.0:1234

--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -18,13 +18,12 @@ spec:
       containers:
         - name: buildkitd
           image: docker.io/moby/buildkit:v0.25.2@sha256:0f63d66f8d2de0bd16438284831a3e9ee6ca7cd57b6eb3ed6e38a7a456590fa7
-          args:
-            - --config
-            - /etc/buildkit/buildkitd.toml
-            - --addr
-            - unix:///run/buildkit/buildkitd.sock
-            - --addr
-            - tcp://0.0.0.0:1234
+          command: ["/bin/sh", "/etc/buildkit/entrypoint.sh"]
+          env:
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           ports:
             - name: buildkit
               containerPort: 1234
@@ -60,3 +59,4 @@ spec:
         - name: config
           configMap:
             name: buildkitd-config
+            defaultMode: 0555

--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: buildkit
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: buildkit

--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               containerPort: 6060
           resources:
             requests:
-              cpu: "2"
+              cpu: "4"
               memory: 4Gi
             limits:
               cpu: "4"

--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -14,19 +14,26 @@ spec:
     metadata:
       labels:
         app: buildkit
+      annotations:
+        checksum/config: df4ea3370cc3fa67c0964f7ea374bf200d43d3c1f68ee6f8e8c887cbea1f75a5
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
         - name: buildkitd
-          image: docker.io/moby/buildkit:v0.25.2@sha256:0f63d66f8d2de0bd16438284831a3e9ee6ca7cd57b6eb3ed6e38a7a456590fa7
-          command: ["/bin/sh", "/etc/buildkit/entrypoint.sh"]
+          image: docker.io/moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3
+          args:
+            - --config
+            - /etc/buildkit/buildkitd.toml
           env:
-            - name: POD_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
+            - name: GOMAXPROCS
+              value: "4"
+            - name: BUILDKIT_HOST
+              value: unix:///run/buildkit/buildkitd.sock
           ports:
             - name: buildkit
               containerPort: 1234
+            - name: debug
+              containerPort: 6060
           resources:
             requests:
               cpu: "2"
@@ -42,16 +49,26 @@ spec:
             - name: config
               mountPath: /etc/buildkit
               readOnly: true
+          startupProbe:
+            exec:
+              command: ["buildctl", "debug", "workers"]
+            periodSeconds: 1
+            timeoutSeconds: 1
+            failureThreshold: 60
           readinessProbe:
-            tcpSocket:
-              port: 1234
-            periodSeconds: 5
-            failureThreshold: 6
+            exec:
+              command: ["buildctl", "debug", "workers"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
           livenessProbe:
-            tcpSocket:
-              port: 1234
-            periodSeconds: 15
-            failureThreshold: 4
+            exec:
+              command: ["buildctl", "debug", "workers"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
       volumes:
         - name: cache
           persistentVolumeClaim:
@@ -59,4 +76,3 @@ spec:
         - name: config
           configMap:
             name: buildkitd-config
-            defaultMode: 0555

--- a/apps/objects/buildkit/service.yaml
+++ b/apps/objects/buildkit/service.yaml
@@ -12,3 +12,6 @@ spec:
     - name: buildkit
       port: 1234
       targetPort: 1234
+    - name: debug
+      port: 6060
+      targetPort: 6060


### PR DESCRIPTION
## Summary
Keep privileged BuildKit (native overlay, existing `buildkit-cache` PVC, GHA `tcp://buildkit:1234`) but stop running the stale v0.25.2 image.

v0.25.2 predates the upstream cgroup-namespace entrypoint, so rustc/clang land in `/sys/fs/cgroup/buildkit` on the node. kubelet reports 0 CPU/memory and the 4 CPU / 8Gi limits never apply.

## Change
- Pin `moby/buildkit:v0.33.0@sha256:6c2fa84a6b61ccd72899dde4239f8d5717f05f9a8ca6f3cad185fb1a95a94de3`
- Do not override `command`, so the image entrypoint can `unshare --cgroup --mount`
- Import the useful Wiremind chart pieces that work in privileged mode:
  - OCI GC sized to the 50Gi PVC (`maxUsedSpace=45GB`)
  - `debugAddress` `:6060` on the Service
  - `buildctl debug workers` startup/readiness/liveness probes
  - `GOMAXPROCS=4` from the CPU limit
  - `checksum/config` so ConfigMap edits restart the pod
- Drop the hand-rolled cgroup reparent script

## Not imported
Rootless image, StatefulSet volumeClaimTemplates, empty OTEL env, PDB (single replica), ServiceMonitor (`debugAddress` is pprof, not Prometheus `/metrics`).