### PR TITLE
feat(arc): two cc-lb-4 and two cc-lb-2 runners

### DIFF
--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -3,7 +3,7 @@ githubConfigSecret: github-config
 runnerScaleSetName: cc-lb-2
 
 minRunners: 0
-maxRunners: 1
+maxRunners: 2
 
 controllerServiceAccount:
   namespace: arc-systems
@@ -18,7 +18,7 @@ containerMode:
       requests:
         storage: 10Gi
 
-# leftover medium jobs; image compiles moved to BuildKit
+# clippy/e2e/release-plz: observed ~1c, not 4c. Image compiles stay on BuildKit.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -3,7 +3,7 @@ githubConfigSecret: github-config
 runnerScaleSetName: cc-lb-4
 
 minRunners: 0
-maxRunners: 1
+maxRunners: 2
 
 controllerServiceAccount:
   namespace: arc-systems
@@ -18,7 +18,8 @@ containerMode:
       requests:
         storage: 10Gi
 
-# clippy/nextest/e2e; request 3 so k3s keeps a core
+# clippy/nextest/e2e used to serialize here; max 2 fits two 3c/8Gi pods on rock5bp.
+# request 3 so a 4-core node still leaves a core for k3s.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:


### PR DESCRIPTION
## Summary
cc-lb-4 was `maxRunners: 1`, so clippy/e2e/nextest serialized on one 3 CPU / 8Gi pod while cluster util sat around 35%.

rock5bp still has room for a second 3-core pod (`4.89+3 < 8`). Raise cc-lb-4 and cc-lb-2 to max 2. Companion cc-lb PR moves clippy/e2e/release-plz onto `cc-lb-2` (observed ~1.3 CPU).
