### PR TITLE
feat(arc): uncap cc-lb pools under 4 CPU

### DIFF
--- a/values/gha-runner-scale-set/cc-lb-1.yaml
+++ b/values/gha-runner-scale-set/cc-lb-1.yaml
@@ -3,7 +3,7 @@ githubConfigSecret: github-config
 runnerScaleSetName: cc-lb-1
 
 minRunners: 0
-maxRunners: 2
+
 
 controllerServiceAccount:
   namespace: arc-systems
@@ -18,7 +18,8 @@ containerMode:
       requests:
         storage: 10Gi
 
-# cargo-deny and other rustc-install jobs
+# cargo-deny and other rustc-install jobs.
+# No maxRunners: ARC omits the cap and scales with the GitHub queue.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:

--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -3,7 +3,7 @@ githubConfigSecret: github-config
 runnerScaleSetName: cc-lb-2
 
 minRunners: 0
-maxRunners: 2
+
 
 controllerServiceAccount:
   namespace: arc-systems
@@ -19,6 +19,7 @@ containerMode:
         storage: 10Gi
 
 # clippy/e2e/release-plz: observed ~1c, not 4c. Image compiles stay on BuildKit.
+# No maxRunners: ARC omits the cap and scales with the GitHub queue.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:

--- a/values/gha-runner-scale-set/cc-lb-500m.yaml
+++ b/values/gha-runner-scale-set/cc-lb-500m.yaml
@@ -3,7 +3,7 @@ githubConfigSecret: github-config
 runnerScaleSetName: cc-lb-500m
 
 minRunners: 0
-maxRunners: 2
+
 
 controllerServiceAccount:
   namespace: arc-systems
@@ -18,7 +18,8 @@ containerMode:
       requests:
         storage: 10Gi
 
-# fmt/promtool/web/helm and docker-build clients; compile runs on BuildKit
+# fmt/promtool/web/helm and docker-build clients; compile runs on BuildKit.
+# No maxRunners: ARC omits the cap and scales with the GitHub queue.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:


### PR DESCRIPTION
## Summary
`cc-lb-500m`, `cc-lb-1`, and `cc-lb-2` request under 4 CPU. Drop `maxRunners` so ARC does not emit a cap and the GitHub queue is the limit.

`cc-lb-4` stays at max 2 (3 CPU / 8Gi).
