### PR TITLE
chore(k8s): upgrade core platform patches

### DIFF
--- a/apps/objects/k3s-system-upgrade/k3s-upgrade-plan.yaml
+++ b/apps/objects/k3s-system-upgrade/k3s-upgrade-plan.yaml
@@ -17,7 +17,7 @@ spec:
   upgrade:
     image: rancher/k3s-upgrade
   channel: https://update.k3s.io/v1-release/channels/latest
-  version: v1.36.3+k3s1
+  version: v1.36.4+k3s1
 ---
 # Agent plan
 apiVersion: upgrade.cattle.io/v1
@@ -41,4 +41,4 @@ spec:
   upgrade:
     image: rancher/k3s-upgrade
   channel: https://update.k3s.io/v1-release/channels/latest
-  version: v1.36.3+k3s1
+  version: v1.36.4+k3s1

--- a/argocd/apps/cilium.yaml
+++ b/argocd/apps/cilium.yaml
@@ -16,7 +16,7 @@ spec:
       ref: homelab
     - chart: cilium
       repoURL: https://helm.cilium.io/
-      targetRevision: 1.20.0
+      targetRevision: 1.20.1
       helm:
         releaseName: cilium
         valueFiles:

--- a/argocd/apps/cloudflare-gateway.yaml
+++ b/argocd/apps/cloudflare-gateway.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/kubernetes-sigs/gateway-api.git
     path: config/crd/standard
-    targetRevision: v1.6.1
+    targetRevision: v1.6.2
   ignoreDifferences:
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition

--- a/cluster-setup/k3s.yaml
+++ b/cluster-setup/k3s.yaml
@@ -106,7 +106,7 @@
         atomic: yes
         chart_ref: cilium
         chart_repo_url: https://helm.cilium.io/
-        chart_version: 1.20.0
+        chart_version: 1.20.1
         kubeconfig: /etc/rancher/k3s/k3s.yaml
         release_name: cilium
         release_namespace: kube-system

--- a/nix/scripts/check-migration.py
+++ b/nix/scripts/check-migration.py
@@ -4315,7 +4315,7 @@ require(
     'systemctl enable iscsid.service "$ISCSI_LOGIN_SERVICE"',
     'systemctl start iscsid.service "$ISCSI_LOGIN_SERVICE"',
     "reconcile_distro_packages",
-    "--version 1.20.0",
+    "--version 1.20.1",
     "etc-state.tar",
     "policy-rc.d",
     "FIREWALL_SERVICE",
@@ -4912,7 +4912,7 @@ require(
     "apps/objects/k3s-system-upgrade/k3s-upgrade-plan.yaml",
     "name: server-plan",
     "name: agent-plan",
-    "version: v1.36.3+k3s1",
+    "version: v1.36.4+k3s1",
     "image: rancher/k3s-upgrade",
 )
 if (root / "nix/k3s-package.nix").exists():

--- a/nix/scripts/homelab-host
+++ b/nix/scripts/homelab-host
@@ -1934,11 +1934,11 @@ REMOTE_VERIFY
     cluster=${2:?cluster required}; test "$cluster" = backbone
     context=${BOOTSTRAP_CONTEXT:-homelab-backbone}; values="$root/values/cilium/backbone.yaml"
     if kubectl --context "$context" get --raw=/readyz >/dev/null 2>&1; then
-      helm --kube-context "$context" diff upgrade cilium cilium --repo https://helm.cilium.io --version 1.20.0 --namespace kube-system --values "$values" >/dev/null
+      helm --kube-context "$context" diff upgrade cilium cilium --repo https://helm.cilium.io --version 1.20.1 --namespace kube-system --values "$values" >/dev/null
       printf 'existing cluster: Cilium dry-run diff completed; release ownership unchanged\n'
     else
       test "${ALLOW_NEW_CLUSTER_BOOTSTRAP:-}" = yes
-      helm --kube-context "$context" upgrade --install cilium cilium --repo https://helm.cilium.io --version 1.20.0 --namespace kube-system --create-namespace --atomic --wait --values "$values"
+      helm --kube-context "$context" upgrade --install cilium cilium --repo https://helm.cilium.io --version 1.20.1 --namespace kube-system --create-namespace --atomic --wait --values "$values"
       kubectl --context "$context" -n kube-system rollout status ds/cilium --timeout=10m
       kubectl --context "$context" -n kube-system rollout status ds/cilium-envoy --timeout=10m
       kubectl --context "$context" -n kube-system rollout status deploy/cilium-operator --timeout=10m


### PR DESCRIPTION
## What
- upgrade Gateway API CRDs from v1.6.1 to v1.6.2
- upgrade Cilium from 1.20.0 to 1.20.1
- upgrade K3s server and agent plans from v1.36.3+k3s1 to v1.36.4+k3s1

## Why
Apply the low-risk core platform patch updates before the remaining Kubernetes workload upgrades.

## Rollout
1. Gateway API CRDs reconcile through Argo server-side apply.
2. Cilium rolls out after the CRDs.
3. K3s upgrades control-plane nodes one at a time, then agents through the existing prepare dependency.

## Verification
- Cilium 1.20.1 rendered with the deployed values
- Gateway API v1.6.2 server-side dry-run succeeded with the Argo field manager
- K3s Plan server-side dry-run succeeded
- git diff --check passed