### PR TITLE
chore(k8s): upgrade operations components

### DIFF
--- a/argocd/apps/argocd.yaml
+++ b/argocd/apps/argocd.yaml
@@ -17,7 +17,7 @@ spec:
           - values.yaml
           - $homelab/values/argo-cd/backbone.yaml
       repoURL: https://argoproj.github.io/argo-helm
-      targetRevision: 10.3.3
+      targetRevision: 10.7.2
   ignoreDifferences:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute

--- a/argocd/apps/loki.yaml
+++ b/argocd/apps/loki.yaml
@@ -20,7 +20,7 @@ spec:
           - values.yaml
           - $homelab/values/loki/backbone.yaml
       repoURL: https://grafana-community.github.io/helm-charts
-      targetRevision: 18.11.7
+      targetRevision: 18.12.1
   syncPolicy:
     automated:
       prune: true

--- a/argocd/appsets/external-secrets.yaml
+++ b/argocd/appsets/external-secrets.yaml
@@ -28,7 +28,7 @@ spec:
               - values.yaml
               - '$homelab/values/external-secrets/{{name}}.yaml'
           repoURL: https://charts.external-secrets.io
-          targetRevision: 2.9.0
+          targetRevision: 2.10.0
       syncPolicy:
         automated:
           prune: true

--- a/argocd/appsets/prometheus-stack.yaml
+++ b/argocd/appsets/prometheus-stack.yaml
@@ -28,7 +28,7 @@ spec:
               - values.yaml
               - '$homelab/values/kube-prometheus-stack/{{cluster}}.yaml'
           repoURL: https://prometheus-community.github.io/helm-charts
-          targetRevision: 88.6.2
+          targetRevision: 89.2.1
       syncPolicy:
         automated:
           prune: true

--- a/values/kube-prometheus-stack/backbone.yaml
+++ b/values/kube-prometheus-stack/backbone.yaml
@@ -623,6 +623,9 @@ grafana:
       memory: 384Mi
 
   sidecar:
+    image:
+      tag: 2.11.2
+      sha: 2912be006f62f9ea080194cf6d3afcd90daead8d101d0ba686a137a849f6a4f6
     resources:
       requests:
         cpu: 20m


### PR DESCRIPTION
## What
- upgrade External Secrets 2.9.0 to 2.10.0
- upgrade kube-prometheus-stack 88.6.2 to 89.2.1
- pin Grafana k8s-sidecar 2.11.2 by digest
- upgrade Argo CD chart 10.3.3 to 10.7.2
- upgrade Loki chart 18.11.7 to 18.12.1

## Safety
- backed up the live Grafana SQLite database before rollout
- retained the existing Prometheus CRD upgrade job
- no incompatible GF_*__FILE, GF_INSTALL_PLUGINS, or /tmp mounts are configured

## Verification
- all four candidate charts rendered with deployed values
- rendered Grafana sidecars include the expected 2.11.2 digest
- git diff --check passed