### PR TITLE
chore(k8s): upgrade stateful applications

### DIFF
--- a/argocd/apps/actions-runner-controller.yaml
+++ b/argocd/apps/actions-runner-controller.yaml
@@ -146,7 +146,7 @@ spec:
         valueFiles:
           - $homelab/values/gha-cache-server/backbone.yaml
       repoURL: ghcr.io/falcondev-oss/charts
-      targetRevision: 1.0.3
+      targetRevision: 1.1.3
   syncPolicy:
     automated:
       prune: true

--- a/argocd/apps/hindsight.yaml
+++ b/argocd/apps/hindsight.yaml
@@ -56,7 +56,7 @@ spec:
           - values.yaml
           - $homelab/values/hindsight/backbone.yaml
       repoURL: ghcr.io/vectorize-io/charts
-      targetRevision: 0.9.1
+      targetRevision: 0.9.2
   syncPolicy:
     automated:
       prune: true

--- a/argocd/apps/versitygw-hdd.yaml
+++ b/argocd/apps/versitygw-hdd.yaml
@@ -15,7 +15,7 @@ spec:
       ref: homelab
     - chart: versitygw
       repoURL: ghcr.io/versity/versitygw/charts
-      targetRevision: 0.3.5
+      targetRevision: 0.4.1
       helm:
         releaseName: versitygw-hdd
         valueFiles:

--- a/argocd/apps/versitygw.yaml
+++ b/argocd/apps/versitygw.yaml
@@ -15,7 +15,7 @@ spec:
       ref: homelab
     - chart: versitygw
       repoURL: ghcr.io/versity/versitygw/charts
-      targetRevision: 0.3.5
+      targetRevision: 0.4.1
       helm:
         releaseName: versitygw
         valueFiles:

--- a/values/gha-cache-server/backbone.yaml
+++ b/values/gha-cache-server/backbone.yaml
@@ -2,12 +2,14 @@ fullnameOverride: gha-cache-server
 
 image:
   repository: ghcr.io/falcondev-oss/github-actions-cache-server
-  tag: 9.4.7@sha256:318a568e4eba358dbe5978338353a4101b527996a076746ba781a32c6ed19543
+  tag: 9.7.0@sha256:3999b0202ec509f3b2084ef92cc50b408838e0d442b5997dd6dff2d89f4fe7b4
 
 config:
   apiBaseUrl: http://gha-cache-server.arc-systems.svc.cluster.local:3000
   cacheCleanupOlderThanDays: 14
-  cacheMaxSizeBytes: 42949672960
+  cacheMaxSizeBytes: "42949672960"
+  cacheFilesystemMaxUsagePercent: 90
+  orphanedStorageGracePeriodHours: 24
   storage:
     driver: filesystem
     filesystem:

--- a/values/hindsight/backbone.yaml
+++ b/values/hindsight/backbone.yaml
@@ -3,7 +3,7 @@
 api:
   replicaCount: 1
   image:
-    tag: "0.9.1-slim"
+    tag: "0.9.2-slim"
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
## What
- upgrade GitHub Actions cache chart 1.0.3 to 1.1.3 and app image 9.4.7 to 9.7.0
- pin cache capacity eviction and orphaned-storage cleanup policies explicitly
- upgrade Hindsight API and control plane from 0.9.1 to 0.9.2
- upgrade both VersityGW releases from chart 0.3.5 to 0.4.1

## Safety
- created and completed a fresh Hindsight CNPG barmanObjectStore backup before deployment
- VersityGW application image remains v1.7.0; this is a chart/security-context update
- GHA cache PVC was at 1% utilization before the update

## Verification
- all releases rendered with the deployed values
- Hindsight API/control-plane images both resolve to 0.9.2
- GHA app tag and digest match, and cleanup environment values render exactly
- git diff --check passed