### PR TITLE
chore(k8s): upgrade registry mirrors

### DIFF
--- a/apps/objects/registry-mirror/docker-io.yaml
+++ b/apps/objects/registry-mirror/docker-io.yaml
@@ -41,6 +41,11 @@ metadata:
     app: registry-docker-io
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: registry-docker-io
@@ -49,9 +54,10 @@ spec:
       labels:
         app: registry-docker-io
     spec:
+      enableServiceLinks: false
       containers:
         - name: registry
-          image: docker.io/library/registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+          image: docker.io/library/registry:3.1.1@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33
           ports:
             - name: registry
               containerPort: 5000
@@ -63,7 +69,7 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: config
-              mountPath: /etc/docker/registry
+              mountPath: /etc/distribution
               readOnly: true
             - name: data
               mountPath: /var/lib/registry

--- a/apps/objects/registry-mirror/ghcr-io.yaml
+++ b/apps/objects/registry-mirror/ghcr-io.yaml
@@ -41,6 +41,11 @@ metadata:
     app: registry-ghcr-io
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: registry-ghcr-io
@@ -49,9 +54,10 @@ spec:
       labels:
         app: registry-ghcr-io
     spec:
+      enableServiceLinks: false
       containers:
         - name: registry
-          image: docker.io/library/registry:2.8.3@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+          image: docker.io/library/registry:3.1.1@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33
           ports:
             - name: registry
               containerPort: 5000
@@ -63,7 +69,7 @@ spec:
               memory: 1Gi
           volumeMounts:
             - name: config
-              mountPath: /etc/docker/registry
+              mountPath: /etc/distribution
               readOnly: true
             - name: data
               mountPath: /var/lib/registry


### PR DESCRIPTION
## What
- upgrade Docker Hub and GHCR pull-through mirrors from Distribution 2.8.3 to 3.1.1
- move the configuration mount from `/etc/docker/registry` to the v3 `/etc/distribution` path
- disable Kubernetes service-link environment injection, which Registry v3 warns about
- set `maxSurge: 0` and `maxUnavailable: 1` so the shared RWO cache PVC is never opened by two registry pods concurrently

## Safety
- cache data is disposable and the filesystem root remains `/var/lib/registry`
- proxy upstreams, NodePorts, PVCs, and services are unchanged
- a canary using each existing ConfigMap passed `/v2/` and upstream manifest fetches

## Verification
- both manifests passed server-side dry-run with the Argo field manager
- Docker Hub proxy returned 200 for `library/alpine:latest`
- GHCR proxy returned 200 for `falcondev-oss/github-actions-cache-server:9.7.0`
- git diff --check passed