### PR TITLE
chore(k8s): upgrade low-risk control plane charts

### DIFF
--- a/argocd/apps/argocd.yaml
+++ b/argocd/apps/argocd.yaml
@@ -17,7 +17,7 @@ spec:
           - values.yaml
           - $homelab/values/argo-cd/backbone.yaml
       repoURL: https://argoproj.github.io/argo-helm
-      targetRevision: 10.7.2
+      targetRevision: 10.8.0
   ignoreDifferences:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute

--- a/argocd/appsets/prometheus-stack.yaml
+++ b/argocd/appsets/prometheus-stack.yaml
@@ -28,7 +28,7 @@ spec:
               - values.yaml
               - '$homelab/values/kube-prometheus-stack/{{cluster}}.yaml'
           repoURL: https://prometheus-community.github.io/helm-charts
-          targetRevision: 89.2.1
+          targetRevision: 89.2.2
       syncPolicy:
         automated:
           prune: true

--- a/values/argo-cd/backbone.yaml
+++ b/values/argo-cd/backbone.yaml
@@ -94,6 +94,11 @@ dex:
   enabled: false
 
 redis:
+  image:
+    repository: ecr-public.aws.com/docker/library/redis
+    tag: 8.6.6-alpine@sha256:75934ddb37bfaebe3b4082ba673cac39f66495244134f33dd0a502ce03cdcd36
+    imagePullPolicy: IfNotPresent
+
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
## What
- upgrade Argo CD chart 10.7.2 to 10.8.0
- pin Argo Redis 8.6.6-alpine to the resolved ECR Public manifest digest
- upgrade kube-prometheus-stack 89.2.1 to 89.2.2

## Why
Redis 8.6.6 contains security fixes. The two chart updates are render-equivalent for the deployed configuration apart from metadata and the Redis override.

## Verification
- Argo CD 10.8.0 Helm render and Kubernetes server-side dry-run
- kube-prometheus-stack 89.2.2 Helm render and Kubernetes server-side dry-run
- git diff --check
- Redis digest resolved by pulling the exact ECR Public image on the cluster

## Rollback
Revert this commit. Redis has no persistent PVC in this deployment, and the chart updates do not introduce migrations.