### PR TITLE
chore(k8s): pin controller workload images

### DIFF
--- a/argocd/apps/cloudflare-gateway.yaml
+++ b/argocd/apps/cloudflare-gateway.yaml
@@ -48,6 +48,17 @@ spec:
     repoURL: https://github.com/pl4nty/cloudflare-kubernetes-gateway.git
     path: config/default
     targetRevision: v0.10.1
+    kustomize:
+      patches:
+        - target:
+            group: apps
+            version: v1
+            kind: Deployment
+            name: controller-manager
+          patch: |
+            - op: replace
+              path: /spec/template/spec/containers/0/env/0/value
+              value: docker.io/cloudflare/cloudflared:2026.8.3@sha256:51c9cefcb4569df44e1ad403ab1d3d8065aa8e84339bcfc6aee75502e1140339
   syncPolicy:
     automated:
       prune: true

--- a/argocd/apps/cosi.yaml
+++ b/argocd/apps/cosi.yaml
@@ -15,6 +15,8 @@ spec:
     targetRevision: v0.2.2
     kustomize:
       namespace: object-storage
+      images:
+        - gcr.io/k8s-staging-sig-storage/objectstorage-controller=gcr.io/k8s-staging-sig-storage/objectstorage-controller:v0.2.2@sha256:1a403232505f78038737f3ffee2da053138a3acb7e225ff81c35980029fad162
       patches:
         - target:
             kind: Deployment


### PR DESCRIPTION
## What
- patch cloudflare-kubernetes-gateway to create cloudflared 2026.8.3 workloads
- override the COSI controller snapshot image with the official v0.2.2 image
- pin both multi-architecture images by digest

## Why
The Cloudflare controller upstream manifest still generates 2026.7.1 tunnel Pods. The COSI v0.2.2 Git tag still references a release-candidate snapshot image instead of the official v0.2.2 tag.

## Verification
- rendered both upstream Kustomize trees with the exact patches
- confirmed the resulting deployment values and image references
- pulled both pinned images on the cluster and matched imageID digests
- Kubernetes server-side dry-run of both Argo Applications
- git diff --check

## Rollback
Revert this commit. Existing resources and CRDs are unchanged; only future cloudflared Pods and the COSI controller image change.