### PR TITLE
chore(k8s): upgrade VersityGW HDD to v1.8.0

### DIFF
--- a/values/versitygw-hdd/backbone.yaml
+++ b/values/versitygw-hdd/backbone.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.7.0
+  tag: v1.8.0@sha256:30292fc2eeacc67a36993b01f7a7a5e3361a19cced0e80c1d71cfa2a4b0a2499
 
 strategy:
   type: Recreate


### PR DESCRIPTION
## What
Upgrade the HDD-backed VersityGW canary from v1.7.0 to v1.8.0 and pin the image manifest digest.

## Why
This stages the IAM and S3 behavior changes on the secondary object-storage instance before the primary instance.

## Verification
- rendered chart 0.4.1 with the deployed HDD values
- Kubernetes server-side dry-run
- pulled the exact pinned multi-architecture image on the cluster
- git diff --check

## Rollout
The Deployment uses Recreate, so a short interruption is expected. Merge only after the scheduled 02:00 UTC Hindsight backup finishes, then verify S3 and COSI-dependent operations before upgrading the primary instance.

## Rollback
Revert to v1.7.0. The v1.8.0 release does not declare a storage-format migration.