### PR TITLE
chore(k8s): upgrade primary VersityGW to v1.8.0

### DIFF
--- a/values/versitygw/backbone.yaml
+++ b/values/versitygw/backbone.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: v1.7.0
+  tag: v1.8.0@sha256:30292fc2eeacc67a36993b01f7a7a5e3361a19cced0e80c1d71cfa2a4b0a2499
 
 strategy:
   type: Recreate


### PR DESCRIPTION
## What
Upgrade the primary VersityGW instance from v1.7.0 to v1.8.0 with the same pinned digest verified on the HDD canary.

## Why
Promote the release only after the secondary instance serves S3 operations and a post-upgrade CNPG backup successfully.

## Verification
- chart 0.4.1 render with primary values
- Kubernetes server-side dry-run
- digest already pulled and exercised on the HDD-backed canary
- git diff --check

## Rollout
The Deployment uses Recreate and will have a short interruption. Merge only after the HDD canary post-upgrade backup completes.

## Rollback
Revert to v1.7.0. No chart or storage schema change is included.