### PR TITLE
chore(k8s): upgrade ZFS LocalPV to 2.11.1

### DIFF
--- a/argocd/apps/zfs-localpv.yaml
+++ b/argocd/apps/zfs-localpv.yaml
@@ -20,7 +20,7 @@ spec:
           - values.yaml
           - $homelab/values/zfs-localpv/backbone.yaml
       repoURL: https://openebs.github.io/zfs-localpv
-      targetRevision: 2.10.1
+      targetRevision: 2.11.1
   syncPolicy:
     automated:
       prune: true

--- a/values/zfs-localpv/backbone.yaml
+++ b/values/zfs-localpv/backbone.yaml
@@ -1,3 +1,10 @@
+zfsPlugin:
+  image:
+    registry: docker.io/
+    repository: openebs/zfs-driver
+    pullPolicy: IfNotPresent
+    tag: 2.11.1@sha256:16f1a74bb2495c78f9652be5d7cd6e869cb212c9decd42cac63e6566b07fa5f2
+
 # zfsNode contains the configurables for
 # the zfs node daemonset
 zfsNode:


### PR DESCRIPTION
## What
- upgrade zfs-localpv chart 2.10.1 to 2.11.1
- pin docker.io/openebs/zfs-driver 2.11.1 by multi-architecture digest

## Why
The release adds StorageClass format options and node defaults while preserving existing fields and volume formats.

## Safety
Created host-level ZFS snapshots for all six currently bound ZFS CSI volumes before this change:
- Immich CNPG data and WAL
- Hindsight CNPG data and WAL
- Immich data
- Jellyfin config

## Verification
- chart render with deployed values
- Kubernetes server-side dry-run
- exact image pull and imageID digest match
- git diff --check

## Rollout
The node plugin runs only on rock5bp and will be replaced once. Existing volumes remain mounted; verify all six claims and provision/mount/delete a temporary PVC after rollout.

## Rollback
Revert the chart and image pin to 2.10.1. Pre-upgrade snapshots are named `pre-zfs-localpv-2.11.1-20260905`.