### PR TITLE
fix(k8s): preserve XFS provisioning after ZFS upgrade

### DIFF
--- a/values/zfs-localpv/backbone.yaml
+++ b/values/zfs-localpv/backbone.yaml
@@ -8,6 +8,8 @@ zfsPlugin:
 # zfsNode contains the configurables for
 # the zfs node daemonset
 zfsNode:
+  defaultFormatOptions:
+    xfs: "-s size=4096"
   resources:
     limits:
       cpu: 100m


### PR DESCRIPTION
## What
- configure `zfsNode.defaultFormatOptions.xfs` as `-s size=4096`
- keep all existing StorageClass objects and parameters unchanged

## Why
After the ZFS LocalPV 2.11.1 rollout, a new XFS PVC exposed that the bundled `mkfs.xfs` rejects ZVOLs whose reported physical sector size follows `volblocksize` (8K or 128K) while XFS defaults to 4K filesystem blocks. The node-level format default is the upstream-supported compatibility setting and avoids immutable StorageClass replacements.

## Verification
- Helm render contains `--default-format-options=xfs=-s size=4096` on `openebs-zfs-plugin`
- Kubernetes server-side dry-run passed
- manual format/mount trials passed for temporary 8K and 128K ZVOLs
- temporary 1Gi PVC bound, an Alpine pod wrote/read the volume, and the Pod/PVC/PV/StorageClass were deleted
- `git diff --check` passed

## Rollback
Revert this commit. Existing volumes are unchanged; the option affects only first-time XFS formatting.