### PR TITLE
chore(k8s): manage RKNPU device plugin with Argo CD

### DIFF
--- a/apps/objects/rknpu-device-plugin/daemonset.yaml
+++ b/apps/objects/rknpu-device-plugin/daemonset.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: rknpu-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      name: rknpu-dp-ds
+  template:
+    metadata:
+      labels:
+        name: rknpu-dp-ds
+    spec:
+      nodeSelector:
+        homelab.bhyoo.com/npu: rknn
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+      containers:
+        - name: rknpu-dp-cntr
+          image: ghcr.io/elct9620/rknpu-device-plugin:f8a6989@sha256:542c5933b4f5d837632eb419abd5c97a3bc1fe8ac6cebc8db6423f81c9210790
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: dp
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: sys
+              mountPath: /sys
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: dp
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: dev
+          hostPath:
+            path: /dev

--- a/argocd/apps/rknpu-device-plugin.yaml
+++ b/argocd/apps/rknpu-device-plugin.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rknpu-device-plugin
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    name: backbone
+    namespace: kube-system
+  project: cluster-management
+  source:
+    repoURL: https://github.com/isac322/homelab.git
+    path: apps/objects/rknpu-device-plugin
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
+      limit: 100


### PR DESCRIPTION
## What
- add a dedicated Argo CD Application for the RKNPU device plugin
- adopt the existing `kube-system` DaemonSet into GitOps
- pin the currently deployed `f8a6989` image to manifest digest `sha256:542c5933...`
- change pull policy from `Always` to `IfNotPresent` now that the image is immutable

## Why
The live device plugin was manually applied and referenced an untagged mutable image. Upstream has no releases or Git tags; the `latest`/`f8a6989` image is the newest runnable arm64 image, while the `main` tag points to an older 2024 arm64 build. This change preserves the known-good binary and makes drift self-healing.

## Verification
- GHCR index digest, arm64 manifest, creation time, and source revision verified
- current live `imageID` matches the pinned digest
- DaemonSet and Application Kubernetes server-side dry-runs passed
- normalized desired DaemonSet matches the live scheduling, mounts, tolerations, update strategy, and security context
- `git diff --check` passed

## Rollback
Revert this commit. If the Application is removed, its finalizer will prune the managed DaemonSet, so rollback should instead restore the prior manual manifest before deleting the Application.