### PR TITLE
chore(k8s): pin Loki gateway nginx digest

### DIFF
--- a/values/loki/backbone.yaml
+++ b/values/loki/backbone.yaml
@@ -76,6 +76,9 @@ sidecar:
     enabled: false
 
 gateway:
+  image:
+    tag: 1.31.5-alpine
+    digest: sha256:aa8c9087d36d93e9d650c5365f883b421e8214aedbad24ade52b844c583358f1
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
## What
- set the Loki gateway nginx tag to `1.31.5-alpine`
- pin its multi-architecture manifest digest to `sha256:aa8c9087...`

## Why
The chart used the floating `1.31-alpine` tag. Docker Hub currently resolves both `1.31-alpine` and `1.31.5-alpine` to the same manifest digest already running in the cluster, so this removes future mutable-tag drift without changing the binary.

## Verification
- Docker Hub manifest digest and supported platforms verified
- live gateway `imageID` matches the pinned digest
- Helm render produces `docker.io/nginxinc/nginx-unprivileged@sha256:aa8c...`
- Kubernetes server-side dry-run passed
- `git diff --check` passed

## Rollback
Revert this commit to resume following the chart's floating `1.31-alpine` tag.