### PR TITLE
feat(nix): manage nvme-cli on Linux hosts

### DIFF
--- a/nix/modules/linux/packages.nix
+++ b/nix/modules/linux/packages.nix
@@ -43,6 +43,7 @@ let
     "vim"
     "htop"
     "wireguard-tools"
+    "nvme-cli"
     "iptables"
   ];
   baseAbsent =


### PR DESCRIPTION
## Summary
- add `nvme-cli` to the common distro package set
- install it through apt on Debian/Ubuntu hosts
- install it through pacman on Arch Linux hosts

## Verification
- `nix flake check --all-systems --no-build`
- topology and migration contract validators
- evaluated all six Linux hosts with exactly one `nvme-cli` entry and the expected package backend