### PR TITLE
refactor(nix): define package ownership boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ nix run .#rotate-psk -- --link wg0-n2p1-n2p2
 - `rock5bp` migration 전후 live 검증에서 NAS baseline, ZFS pool health, democratic-csi PV/PVC binding, VolumeAttachment, iSCSI session이 모두 일치했다. Production restore는 필요하지 않았고, 2026-08-31에 migration 전용 off-host ZFS stream backup 약 226 GiB와 `pre-nix-migration-20260827T091229Z` snapshot/hold를 제거했다. 삭제 후 보존된 manifest를 기준으로 별도 read-only completeness audit을 수행해 17개 zvol stream을 live PV/PVC 및 kubelet mount 또는 VolumeAttachment/iSCSI session에 일대일 대응했고, root stream의 17개 child dataset도 모두 확인했다(18/18 PASS). 삭제 경로와 receipt-pinned recovery/baseline/storage inventory 및 NAS evidence 경로의 disjointness도 검증했다.
 - 각 host는 `prepare -> activate -> reboot -> reboot-verify -> commit`이 terminal receipt로 끝나고 live verification이 통과한 뒤에만 `[ansible_managed]`에서 `[nix_managed]`로 옮긴다.
 
+## Linux package ownership
+
+Linux 호스트의 전역 패키지는 한 관리자가 소유한다. 커널·DKMS·systemd/udev/initramfs 통합, bootstrap·복구, 호스트 네트워크·스토리지 도구는 apt 또는 pacman이 관리한다. 현재 공통 OS 패키지는 `curl`, `vim`, `wireguard-tools`, `nvme-cli`, `iptables`다. 배포판과 독립적인 사용자 공간 도구인 `age`, `htop`, `jq`, `kubectl`, Helm, `sops`는 Nix `environment.systemPackages`가 관리한다.
+`bootstrap-host`는 Nix `age-keygen`이 아직 없을 때만 OS `age`를 임시 설치한다. 일반 호스트는 commit 단계에서 이 bootstrap 패키지를 제거한다. `preserveNasState=true`인 `rock5bp`는 package reconciliation이 읽기 전용이므로, Nix generation 활성화 후 OS `age`를 별도 유지보수로 제거한다.
+
+Nix와 distro 전역 패키지 목록에 같은 이름을 선언하면 module evaluation이 실패한다. Nix app이나 systemd service의 `runtimeInputs`는 해당 프로그램의 `/nix/store` closure에만 고정되므로 전역 소유권 중복으로 보지 않는다. `rock5bp`의 `preserveNasState=true` 계약에서는 distro package reconciliation이 계속 읽기 전용이다.
+
 ## Linux migration
 
 일반 activation은 다음 다섯 단계다. K3s version과 rolling upgrade는 기존 Rancher `system-upgrade-controller`, `server-plan`, `agent-plan`, `backbone-k3s-upgrade` Application이 계속 소유한다. Host migration 중에는 Plan version을 변경하거나 별도 rollout을 시작하지 않는다.

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
               rpi5 = self.systemConfigs.rpi5.config;
               n2p1 = self.systemConfigs.n2p1.config;
               n2p1Commit = self.systemConfigs."n2p1-commit".config;
+              n2p1NixPackages = map lib.getName n2p1.environment.systemPackages;
               macmini = self.systemConfigs.macmini.config;
               macminiK3s = macmini.environment.etc."rancher/k3s/config.yaml".text;
               macminiLan = macmini.environment.etc."systemd/network/10-homelab-lan.network".text;
@@ -182,6 +183,14 @@
                 projectServices self.systemConfigs.${hostName}.config == expected
                 && projectServices self.systemConfigs."${hostName}-commit".config == expected
               ) (builtins.attrNames linuxHosts);
+              globalPackageOwnershipIsExclusive = lib.all (
+                hostName:
+                let
+                  cfg = self.systemConfigs.${hostName}.config;
+                in
+                lib.intersectLists (map lib.getName cfg.environment.systemPackages) cfg.homelab.distroPackages.present
+                == [ ]
+              ) (builtins.attrNames linuxHosts);
               preservationOwnershipIsExplicit = lib.all (
                 hostName:
                 let
@@ -221,6 +230,7 @@
             assert projectServiceOwnershipIsMinimal;
             assert projectEtcOwnershipIsExplicit;
             assert preservationOwnershipIsExplicit;
+            assert globalPackageOwnershipIsExclusive;
             assert topology.nodes.rock5bp.preserveNasState;
             assert !(topology.nodes.n2p1.preserveNasState);
             assert topology.nodes.macmini.k3sRole == "agent";
@@ -237,6 +247,20 @@
             assert builtins.elem "sg3_utils" macmini.homelab.distroPackages.present;
             assert !(builtins.elem "sg3-utils" macmini.homelab.distroPackages.present);
             assert !(builtins.elem "scsitools" macmini.homelab.distroPackages.present);
+            assert builtins.elem "curl" n2p1.homelab.distroPackages.present;
+            assert builtins.elem "wireguard-tools" n2p1.homelab.distroPackages.present;
+            assert builtins.elem "nvme-cli" n2p1.homelab.distroPackages.present;
+            assert builtins.elem "vim" n2p1.homelab.distroPackages.present;
+            assert !(builtins.elem "htop" n2p1.homelab.distroPackages.present);
+            assert !(builtins.elem "vim" n2p1.homelab.distroPackages.absent);
+            assert builtins.elem "age" n2p1.homelab.distroPackages.absent;
+            assert builtins.elem "htop" n2p1.homelab.distroPackages.absent;
+            assert !(builtins.elem "vim" n2p1NixPackages);
+            assert builtins.elem "htop" n2p1NixPackages;
+            assert builtins.elem "age" n2p1NixPackages;
+            assert builtins.elem "jq" n2p1NixPackages;
+            assert !(builtins.elem "curl" n2p1NixPackages);
+            assert !(builtins.elem "wireguard-tools" n2p1NixPackages);
             assert builtins.elem "iptables.service" macmini.systemd.services.homelab-k3s.requires;
             assert builtins.elem "iscsid.service" macmini.systemd.services.homelab-k3s.after;
             assert builtins.elem "iscsi.service" macmini.systemd.services.homelab-k3s.after;

--- a/nix/modules/linux/base.nix
+++ b/nix/modules/linux/base.nix
@@ -77,18 +77,6 @@ in
     services.userborn.enable = true;
     systemd.maskedUnits = disabledServices;
 
-    environment.systemPackages = with pkgs; [
-      age
-      curl
-      htop
-      jq
-      kubectl
-      kubernetes-helm
-      sops
-      vim
-      wireguard-tools
-    ];
-
     environment.etc = {
       hostname = {
         text = "${name}\n";

--- a/nix/modules/linux/packages.nix
+++ b/nix/modules/linux/packages.nix
@@ -8,6 +8,14 @@
 let
   cfg = config.homelab.distroPackages;
   preserveNasState = hostConfig.preserveNasState or false;
+  nixPresent = with pkgs; [
+    age
+    htop
+    jq
+    kubectl
+    kubernetes-helm
+    sops
+  ];
   aptPresent = [
     "locales"
     "systemd-resolved"
@@ -41,29 +49,44 @@ let
   commonPresent = [
     "curl"
     "vim"
-    "htop"
     "wireguard-tools"
     "nvme-cli"
     "iptables"
   ];
+  commonAbsent = [
+    "age"
+    "htop"
+  ];
   baseAbsent =
-    if hostConfig.packageBackend == "pacman" then
-      pacmanAbsent
-    else
-      [
-        "netplan.io"
-        "network-manager"
-        "networkd-dispatcher"
-        "cron"
-        "snapd"
-        "ufw"
-      ];
+    commonAbsent
+    ++ (
+      if hostConfig.packageBackend == "pacman" then
+        pacmanAbsent
+      else
+        [
+          "netplan.io"
+          "network-manager"
+          "networkd-dispatcher"
+          "cron"
+          "snapd"
+          "ufw"
+        ]
+    );
   defaultAbsent =
     if preserveNasState then
       lib.remove (if hostConfig.packageBackend == "pacman" then "cronie" else "cron") baseAbsent
     else
       baseAbsent;
   list = lib.concatMapStringsSep " " lib.escapeShellArg;
+  validateDistroPackages =
+    packages:
+    let
+      globalPackageOverlap = lib.intersectLists (map lib.getName nixPresent) packages;
+    in
+    assert lib.assertMsg (globalPackageOverlap == [ ]) ''
+      Linux packages must have one global owner; these are declared in both Nix and distro packages: ${lib.concatStringsSep ", " globalPackageOverlap}
+    '';
+    packages;
 in
 {
   options.homelab.distroPackages = {
@@ -74,6 +97,7 @@ in
         ++ (if hostConfig.packageBackend == "pacman" then archPresent else aptPresent)
         ++ iscsiClientPresent
         ++ iscsiServerPresent;
+      apply = validateDistroPackages;
     };
     absent = lib.mkOption {
       type = lib.types.listOf lib.types.str;
@@ -86,15 +110,7 @@ in
   };
 
   config = {
-    environment.systemPackages = with pkgs; [
-      vim
-      htop
-      kubectl
-      kubernetes-helm
-      wireguard-tools
-      sops
-      age
-    ];
+    environment.systemPackages = nixPresent;
     system-manager.preActivationAssertions.requiredDistroPackages = {
       enable = true;
       name = "requiredDistroPackages";

--- a/nix/scripts/check-migration.py
+++ b/nix/scripts/check-migration.py
@@ -4107,6 +4107,7 @@ require(
     '"systemd-zram-generator"',
     '"zram-generator"',
     "default = true;",
+    "lib.assertMsg",
 )
 forbid(
     "nix/modules/linux/packages.nix",
@@ -4115,6 +4116,14 @@ forbid(
     "pacman -Syu",
     "homelab-distro-packages",
     "homelab-iscsi-client",
+)
+forbid("nix/modules/linux/base.nix", "environment.systemPackages")
+require(
+    "README.md",
+    "Linux package ownership",
+    "전역 패키지는 한 관리자가 소유한다",
+    "`runtimeInputs`",
+    "`preserveNasState=true`",
 )
 require(
     "nix/modules/linux/firewall.nix",
@@ -4342,9 +4351,17 @@ require(
     "system-manager generation changed after prepare",
     "systemd-timesyncd.service",
     "NTPSynchronized",
-    "age curl git sudo xz",
-    "age ca-certificates curl git sudo xz-utils",
+    "set -- age",
+    "test -x /run/system-manager/sw/bin/age-keygen",
+    r'\"\$@\" curl git sudo xz',
+    r'\"\$@\" ca-certificates curl git sudo xz-utils',
     "command -v git",
+)
+require(
+    "nix/scripts/wireguard-secrets",
+    "age_keygen=/run/system-manager/sw/bin/age-keygen",
+    r'\"\$age_keygen\" -o',
+    r'\"\$age_keygen\" -y',
 )
 forbid("nix/scripts/homelab-host", "sudo -n nix-env")
 forbid("nix/scripts/adopt-host", "sudo -n nix-env")

--- a/nix/scripts/homelab-host
+++ b/nix/scripts/homelab-host
@@ -1297,13 +1297,14 @@ case "${1:-}" in
         trap - EXIT HUP INT TERM
       fi
       . /etc/os-release
+      if test -x /run/system-manager/sw/bin/age-keygen; then set --; else set -- age; fi
       case \"\$ID\" in
         arch|archarm)
-          \$SUDO pacman --noconfirm --needed -S age curl git sudo xz
+          \$SUDO pacman --noconfirm --needed -S \"\$@\" curl git sudo xz
           ;;
         debian|ubuntu|raspbian)
           \$SUDO apt-get update
-          \$SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends age ca-certificates curl git sudo xz-utils
+          \$SUDO env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \"\$@\" ca-certificates curl git sudo xz-utils
           ;;
         *)
           echo \"unsupported bootstrap distribution: \$ID\" >&2
@@ -1314,7 +1315,7 @@ case "${1:-}" in
         curl --proto \"=https\" --tlsv1.2 -fsSL https://nixos.org/nix/install | sh -s -- --daemon --yes
       fi
       test -x /nix/var/nix/profiles/default/bin/nix || command -v nix >/dev/null
-      command -v age-keygen >/dev/null
+      test -x /run/system-manager/sw/bin/age-keygen || command -v age-keygen >/dev/null
       command -v git >/dev/null
       sudo -n true
     '"

--- a/nix/scripts/wireguard-secrets
+++ b/nix/scripts/wireguard-secrets
@@ -60,15 +60,17 @@ case "${1:-}" in
     target=$(nix eval --raw "$root#topology.nodes.$host.sshTarget")
     recipient=$(ssh -o BatchMode=yes "$target" "sudo -n sh -ceu '
       identity=/var/lib/homelab/age.key
+      age_keygen=/run/system-manager/sw/bin/age-keygen
+      if ! test -x \"\$age_keygen\"; then age_keygen=\$(command -v age-keygen); fi
+      test -x \"\$age_keygen\"
       if test ! -s \"\$identity\"; then
         test \"$mode\" != --recipient-only
-        command -v age-keygen >/dev/null
         install -d -m 0700 /var/lib/homelab
         umask 077
-        age-keygen -o \"\$identity\"
+        \"\$age_keygen\" -o \"\$identity\"
         chmod 0600 \"\$identity\"
       fi
-      age-keygen -y \"\$identity\"
+      \"\$age_keygen\" -y \"\$identity\"
     '")
     case "$recipient" in age1*) ;; *) echo "invalid age recipient" >&2; exit 1 ;; esac
     printf '%s %s\n' "$host" "$recipient"


### PR DESCRIPTION
## Summary
- make apt/pacman the global owner of host-integrated and recovery tools (`curl`, `vim`, `wireguard-tools`, `nvme-cli`, `iptables`)
- make Nix the global owner of portable operator tools (`age`, `htop`, `jq`, `kubectl`, Helm, `sops`)
- reject overlapping Nix and distro global package declarations at module evaluation
- purge bootstrap-only distro `age` and distro `htop`, while resolving remote `age-keygen` from the active system-manager generation
- document the ownership contract and preserve the read-only `rock5bp` package boundary

## Verification
- `bash -n` for changed shell scripts
- ShellCheck at warning severity, excluding existing SC1007 findings
- `nix fmt -- --ci`
- `nix flake check --all-systems --no-build`
- topology and migration contract validators
- all six Linux configs evaluated with an empty Nix/distro package intersection
- overlap guard rejects `age` and `htop` as distro-present packages
- all six nodes resolved `/run/system-manager/sw/bin/age-keygen` inside a remote sudo shell and read their existing recipient
- internal reviewer: no findings