### PR TITLE
fix(arc): keep cc-lb-2 and cc-lb-4 off rock5bp

### DIFF
--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -4,7 +4,6 @@ runnerScaleSetName: cc-lb-2
 
 minRunners: 0
 
-
 controllerServiceAccount:
   namespace: arc-systems
   name: arc-gha-rs-controller
@@ -20,10 +19,21 @@ containerMode:
 
 # clippy/e2e/release-plz: observed ~1c, not 4c. Image compiles stay on BuildKit.
 # No maxRunners: ARC omits the cap and scales with the GitHub queue.
+# Heavy jobs stay off rock5bp (unreliable disk). local-path work volumes
+# pin kubernetes-mode job pods to the runner node.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:
   spec:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                    - rock5bp
     containers:
       - name: runner
         image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
@@ -97,6 +107,15 @@ template:
 
 listenerTemplate:
   spec:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                    - rock5bp
     containers:
       - name: listener
         resources:

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -19,11 +19,21 @@ containerMode:
         storage: 10Gi
 
 # nextest-cov p95 4.4c / 4.7Gi; e2e/clippy ~2.8c. 4c/6Gi on 8-core nodes.
-# max 2: two pods need 8c/12Gi, which fits rock5bp.
+# Heavy jobs stay off rock5bp (unreliable disk). local-path work volumes
+# pin kubernetes-mode job pods to the runner node.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:
   spec:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                    - rock5bp
     containers:
       - name: runner
         image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
@@ -97,6 +107,15 @@ template:
 
 listenerTemplate:
   spec:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                    - rock5bp
     containers:
       - name: listener
         resources:


### PR DESCRIPTION
## Summary
rock5bp disk cannot take heavy ARC jobs. Keep `cc-lb-2` and `cc-lb-4` off that node so runner pods and their local-path work volumes land elsewhere.

## Changes
- required nodeAffinity `kubernetes.io/hostname NotIn rock5bp` on runner and listener templates for `cc-lb-2` and `cc-lb-4`
- `cc-lb-1` and `cc-lb-500m` unchanged

Argo `arc-cc-lb-2` / `arc-cc-lb-4` sync from `HEAD`. Existing runner pods on rock5bp recycle on the next scale-set hash update.