### PR TITLE
fix(buildkit): prefer rock5bp over macmini

### DIFF
--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       annotations:
         checksum/config: df4ea3370cc3fa67c0964f7ea374bf200d43d3c1f68ee6f8e8c887cbea1f75a5
     spec:
+      # 4c/4Gi pack collides with cc-lb-4 on macmini. Cache is already
+      # iSCSI from rock5bp; run the pod on that node.
+      nodeSelector:
+        kubernetes.io/hostname: rock5bp
       terminationGracePeriodSeconds: 30
       containers:
         - name: buildkitd

--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -19,10 +19,18 @@ spec:
       annotations:
         checksum/config: df4ea3370cc3fa67c0964f7ea374bf200d43d3c1f68ee6f8e8c887cbea1f75a5
     spec:
-      # 4c/4Gi pack collides with cc-lb-4 on macmini. Cache is already
-      # iSCSI from rock5bp; run the pod on that node.
-      nodeSelector:
-        kubernetes.io/hostname: rock5bp
+      # Prefer rock5bp so macmini can pack cc-lb-4. Soft preference only:
+      # schedule elsewhere if rock5bp cannot take 4c/4Gi.
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - rock5bp
       terminationGracePeriodSeconds: 30
       containers:
         - name: buildkitd


### PR DESCRIPTION
## Summary
macmini cannot pack both 4c buildkit and 4c/6Gi `cc-lb-4`. Prefer rock5bp for buildkit so macmini can take a `cc-lb-4` runner. This is a scheduler preference, not a pin.

## Changes
- `preferredDuringSchedulingIgnoredDuringExecution` weight 100 for `kubernetes.io/hostname In rock5bp`
- no `nodeSelector`; if rock5bp cannot fit 4c/4Gi, buildkit can land elsewhere
- cache PVC is already democratic-csi iSCSI (`portal: rock5bp:3260`)

`cc-lb-4` `maxRunners: 2` still cannot fit two 4c/6Gi pods on macmini alone.