### PR TITLE
fix(arc): drop rock5bp disk scheduling workarounds

### DIFF
--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -19,18 +19,6 @@ spec:
       annotations:
         checksum/config: df4ea3370cc3fa67c0964f7ea374bf200d43d3c1f68ee6f8e8c887cbea1f75a5
     spec:
-      # Prefer rock5bp so macmini can pack cc-lb-4. Soft preference only:
-      # schedule elsewhere if rock5bp cannot take 4c/4Gi.
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: kubernetes.io/hostname
-                    operator: In
-                    values:
-                      - rock5bp
       terminationGracePeriodSeconds: 30
       containers:
         - name: buildkitd

--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -19,21 +19,10 @@ containerMode:
 
 # clippy/e2e/release-plz: observed ~1c, not 4c. Image compiles stay on BuildKit.
 # No maxRunners: ARC omits the cap and scales with the GitHub queue.
-# Heavy jobs stay off rock5bp (unreliable disk). local-path work volumes
-# pin kubernetes-mode job pods to the runner node.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:
   spec:
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: NotIn
-                  values:
-                    - rock5bp
     containers:
       - name: runner
         image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
@@ -107,15 +96,6 @@ template:
 
 listenerTemplate:
   spec:
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: NotIn
-                  values:
-                    - rock5bp
     containers:
       - name: listener
         resources:

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -19,21 +19,10 @@ containerMode:
         storage: 10Gi
 
 # nextest-cov p95 4.4c / 4.7Gi; e2e/clippy ~2.8c. 4c/6Gi on 8-core nodes.
-# Heavy jobs stay off rock5bp (unreliable disk). local-path work volumes
-# pin kubernetes-mode job pods to the runner node.
 # No DinD. Image builds go to buildkit.arc-systems.svc:1234.
 # actions/cache talks to the in-cluster cache server, not GitHub.
 template:
   spec:
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: NotIn
-                  values:
-                    - rock5bp
     containers:
       - name: runner
         image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
@@ -107,15 +96,6 @@ template:
 
 listenerTemplate:
   spec:
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: NotIn
-                  values:
-                    - rock5bp
     containers:
       - name: listener
         resources:


### PR DESCRIPTION
## Summary
rock5bp hardware is healthy again. Drop the scheduling workarounds that kept heavy ARC jobs off that node and that preferred buildkit onto it so macmini could pack `cc-lb-4`.

## Changes
- remove required `hostname NotIn rock5bp` from `cc-lb-2` and `cc-lb-4` runner and listener templates
- remove buildkit `preferredDuringSchedulingIgnoredDuringExecution` for rock5bp

Jellyfin pin and zfs-localpv topology stay; those are NAS placement, not disk workarounds.