### PR TITLE
fix(buildkit): cap worker parallelism at two

### DIFF
--- a/apps/objects/buildkit/configmap.yaml
+++ b/apps/objects/buildkit/configmap.yaml
@@ -21,7 +21,7 @@ data:
       reservedSpace = "10GB"
       maxUsedSpace = "45GB"
       minFreeSpace = "5GB"
-      max-parallelism = 4
+      max-parallelism = 2
 
       [[worker.oci.gcpolicy]]
         keepDuration = "48h"

--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: buildkit
       annotations:
-        checksum/config: df4ea3370cc3fa67c0964f7ea374bf200d43d3c1f68ee6f8e8c887cbea1f75a5
+        checksum/config: b80dda73916f8f9460d1fed69261c1d4f44f56be872c1a9f648f7d08d4a18e32
     spec:
       terminationGracePeriodSeconds: 30
       containers:


### PR DESCRIPTION
## Summary
- lower BuildKit OCI worker `max-parallelism` from 4 to 2
- refresh the pod-template config checksum so Argo CD restarts buildkitd

## Root cause
The cc-lb four-platform release runs fat-LTO links concurrently. The BuildKit container reaches its 8 GiB cgroup limit, is terminated with `OOMKilled`/exit 137, and Buildx reports the resulting gRPC EOF.

## Verification
- reproduced the BuildKit OOM with the cc-lb v0.4.6 four-platform build
- confirmed two concurrent link processes nearly consume the current 8 GiB limit
- `kubectl apply --dry-run=client --validate=false` accepts both manifests
- `checksum/config` equals the SHA-256 of `configmap.yaml`
- independent review found no blocking issues