### PR TITLE
fix(arc): preserve Recreate strategy and add probe delay for gha-cache-server

### DIFF
--- a/argocd/apps/actions-runner-controller.yaml
+++ b/argocd/apps/actions-runner-controller.yaml
@@ -147,6 +147,11 @@ spec:
           - $homelab/values/gha-cache-server/backbone.yaml
       repoURL: ghcr.io/falcondev-oss/charts
       targetRevision: 1.1.3
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/strategy
   syncPolicy:
     automated:
       prune: true

--- a/values/gha-cache-server/backbone.yaml
+++ b/values/gha-cache-server/backbone.yaml
@@ -21,11 +21,28 @@ config:
 
 resources:
   requests:
-    cpu: 20m
-    memory: 256Mi
-  limits:
     cpu: 100m
     memory: 512Mi
+  limits:
+    memory: 1Gi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: cache
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 5
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: cache
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 5
 
 persistentVolumeClaim:
   enabled: true


### PR DESCRIPTION
## Overview
Fixes the startup deadlock and crashloop on `gha-cache-server` in `arc-systems`.

### Root Cause
1. **RWO PVC Multi-Attach Deadlock**: `gha-cache-server` mounts an SQLite database on an iSCSI ReadWriteOnce volume (`ssd-ha-xfs`). Under the chart default `RollingUpdate` with `maxSurge: 1`, updating the deployment scheduled a new pod on `rock5bp` while the old pod held the volume on `rpi5`, causing a permanent deadlock in `ContainerCreating`.
2. **CPU Throttling on V8 / Nitro Startup**: Under a 100m CPU limit, V8 initialization and Nitro worker spawning took >30s on ARM cores. Because the chart lacked `initialDelaySeconds`, Kubelet's liveness probe timed out at 30s and repeatedly killed the container (exit code 137).

### Solution
- Configured `ignoreDifferences` for `/spec/strategy` on the ArgoCD Application so the `Recreate` deployment strategy is permanently preserved.
- Sized resources to `requests: 100m/512Mi` and `limits: memory: 1Gi` (no CPU limit), allowing fast initialization bursts.
- Added `initialDelaySeconds: 30` to `livenessProbe` and `10` to `readinessProbe` in `values/gha-cache-server/backbone.yaml`.

### Verification
- Pod `gha-cache-server` is now `1/1 Running` with 0 restarts.
- `wget -S -O- http://127.0.0.1:3000/health` returns `HTTP/1.1 200 OK: healthy`.