### PR TITLE
feat(k8s): right-size workload requests to resolve cluster scheduling starvation

### DIFF
--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -48,8 +48,8 @@ spec:
               containerPort: 6060
           resources:
             requests:
-              cpu: "4"
-              memory: 4Gi
+              cpu: 1500m
+              memory: 2Gi
             limits:
               cpu: "6"
               memory: 10Gi

--- a/apps/objects/hermes/isacmes-jay.yaml
+++ b/apps/objects/hermes/isacmes-jay.yaml
@@ -20,7 +20,7 @@ spec:
   resources:
     requests:
       cpu: 200m
-      memory: 4Gi
+      memory: 2Gi
     limits:
       cpu: 2
       memory: 6Gi
@@ -281,8 +281,8 @@ spec:
         periodSeconds: 30
       resources:
         requests:
-          cpu: 200m
-          memory: 1Gi
+          cpu: 100m
+          memory: 768Mi
         limits:
           cpu: 1
           memory: 2Gi

--- a/apps/objects/hermes/isacmes.yaml
+++ b/apps/objects/hermes/isacmes.yaml
@@ -22,7 +22,7 @@ spec:
   resources:
     requests:
       cpu: 200m
-      memory: 4Gi
+      memory: 2Gi
     limits:
       cpu: 2
       memory: 6Gi
@@ -283,8 +283,8 @@ spec:
         periodSeconds: 30
       resources:
         requests:
-          cpu: 200m
-          memory: 1Gi
+          cpu: 100m
+          memory: 768Mi
         limits:
           cpu: 1
           memory: 2Gi

--- a/values/immich/backbone.yaml
+++ b/values/immich/backbone.yaml
@@ -109,7 +109,7 @@ server:
           resources:
             requests:
               cpu: 300m
-              memory: 3Gi
+              memory: 1536Mi
             limits:
               cpu: 2
               memory: 5Gi
@@ -216,8 +216,8 @@ machine-learning:
             privileged: true
           resources:
             requests:
-              cpu: 300m
-              memory: 3Gi
+              cpu: 200m
+              memory: 1536Mi
             limits:
               cpu: 2
               memory: 6Gi

--- a/values/thanos/backbone.yaml
+++ b/values/thanos/backbone.yaml
@@ -72,7 +72,7 @@ storegateway:
   resources:
     requests:
       cpu: 30m
-      memory: 2Gi
+      memory: 1280Mi
     limits:
       cpu: 500m
       memory: 3Gi


### PR DESCRIPTION
## Technical Audit Report: Right-Sizing Workload Requests for Cluster Scheduling

### 1. Background & Root Cause Analysis
Following PR #331 (commit `40e5b21`), workload resource `requests` were tuned upward to match 14-day historical P95/Peak measurements from Thanos in an effort to eliminate CFS throttling and OOM risks. However, sizing requests to individual peak demand eliminated statistical multiplexing across the cluster:
- **`macmini`**: `buildkitd` alone was given `requests: cpu 4` (50% of node capacity), leaving only 3.63 cores available.
- **`rock5bp`**: Memory requests reached 28.7 GiB out of 31.8 GiB allocatable (90% saturation), leaving only ~3.05 GiB free.
- **Immediate Failure**: ARC runner pods for `cc-lb` (`cc-lb-4`, requiring 4c/6Gi) could not be scheduled on any node in the 6-node cluster (`0/6 nodes available: 3 Insufficient cpu, 5 Insufficient memory`), remaining stuck in `Pending` indefinitely despite low actual physical utilization (cluster CPU 15%, memory 30%).

### 2. Multi-Agent Architectural Consensus
A joint consultation between SRE/Reliability and Bin-Packing/Capacity perspectives concluded:
- **`requests`** represent baseline active working sets for scheduling admission and contention guarantees, not worst-case bursts.
- **`limits`** protect nodes from memory leaks and rogue containers via hard OOM containment.
- Burstable and batch workloads (BuildKit, CI runners, browser automation, ML inference) must have `request << limit` to allow cluster elasticity while preventing artificial starvation.

### 3. Changes Applied

| Workload | Container / Component | Old Requests | **New Requests** | Limits (Unchanged) | Rationale |
| :--- | :--- | :--- | :--- | :--- | :--- |
| `buildkit` | `buildkitd` (`macmini`) | 4c / 4Gi | **1500m / 2Gi** | 6c / 10Gi | 95% idle (<1m CPU / 21MiB RAM). Frees 2.5c CPU on `macmini`. |
| `hermes` | `isacmes` main (`rock5bp`) | 200m / 4Gi | **200m / 2Gi** | 2c / 6Gi | Steady-state active ~400MiB. Frees 2Gi RAM on `rock5bp`. |
| `hermes` | `isacmes` camofox (`rock5bp`) | 200m / 1Gi | **100m / 768Mi** | 1c / 2Gi | Steady-state active ~400MiB. Frees 256Mi RAM on `rock5bp`. |
| `hermes` | `isacmes-jay` main (`rock5bp`) | 200m / 4Gi | **200m / 2Gi** | 2c / 6Gi | Steady-state active ~300MiB. Frees 2Gi RAM on `rock5bp`. |
| `hermes` | `isacmes-jay` camofox (`rock5bp`) | 200m / 1Gi | **100m / 768Mi** | 1c / 2Gi | Steady-state active ~440MiB. Frees 256Mi RAM on `rock5bp`. |
| `immich` | `server` main (`rock5bp`) | 300m / 3Gi | **300m / 1536Mi** | 2c / 5Gi | Steady-state active ~640MiB. Frees 1.5Gi RAM on `rock5bp`. |
| `immich` | `machine-learning` (`rock5bp`) | 300m / 3Gi | **200m / 1536Mi** | 2c / 4Gi + NPU | Steady-state active ~350MiB. Frees 1.5Gi RAM on `rock5bp`. |
| `thanos` | `storegateway` (`rock5bp`) | 30m / 2Gi | **30m / 1280Mi** | 500m / 3Gi | Steady-state active ~390MiB. Frees 768Mi RAM on `rock5bp`. |

### 4. Cluster Capacity Recovery
- **`macmini` CPU Request Headroom**: Increases from **3.63c** to **6.13c** (+2.5 cores free), immediately allowing `cc-lb-4` (4 cores) to schedule.
- **`rock5bp` Memory Request Headroom**: Increases from **3.05 GiB** to **~11.4 GiB** (+8.3 GiB free), resolving storage node saturation.
- **Cluster Total Freed Capacity**: **2.8 cores CPU**, **10.25 GiB RAM**.

### 5. Verification
- `git diff --check`: Passed cleanly.
- `nix flake check --all-systems --no-build`: Passed across all outputs.
- `kubectl apply --dry-run=client -f ...`: Verified on `buildkit`, `isacmes`, and `isacmes-jay`.
- Ruby Psych YAML parser validation: Passed on `values/immich/backbone.yaml` and `values/thanos/backbone.yaml`.
