### PR TITLE
fix(k8s): restore Thanos upload path memory headroom

### DIFF
--- a/values/kube-prometheus-stack/backbone.yaml
+++ b/values/kube-prometheus-stack/backbone.yaml
@@ -914,7 +914,7 @@ prometheus:
           cpu: 10m
           memory: 40Mi
         limits:
-          memory: 64Mi
+          memory: 81Mi
       objectStorageConfig:
         existingSecret:
           name: thanos-objstore-config

--- a/values/versitygw-hdd/backbone.yaml
+++ b/values/versitygw-hdd/backbone.yaml
@@ -31,4 +31,4 @@ resources:
     cpu: 150m
     memory: 56Mi
   limits:
-    memory: 160Mi
+    memory: 200Mi


### PR DESCRIPTION
## Why

`prometheus-shared-0` is degraded because both ends of its Thanos upload path were undersized by the September 9 resource tuning:

1. `thanos-sidecar` is repeatedly OOM-killed with exit code 137 immediately after starting upload of block `01M21D44ANG04M6EMS54EW5KXC`.
2. The upload target, `versitygw-hdd`, is also intermittently OOM-killed with exit code 137 while serving Thanos block traffic.

Direct queries against the still-running local Prometheus show:

| Workload | 14d P50 | 14d P99 | 14d max | Longer-window max |
| --- | ---: | ---: | ---: | ---: |
| Thanos sidecar | 30.72Mi | 47.06Mi | 51.55Mi | 64.55Mi (30d) |
| VersityGW HDD | 43.81Mi | 123.56Mi | 125.97Mi | 125.97Mi (30d) |

The sidecar's 64Mi limit is below its observed 30-day maximum. VersityGW reached OOMKill at its 160Mi limit, so 160Mi is a censored lower bound for its legitimate request burst.

## What

- Raise the Thanos sidecar memory limit from 64Mi to 81Mi.
- Raise the VersityGW HDD memory limit from 160Mi to 200Mi.
- Keep both memory requests unchanged because their steady-state P50 values still support 40Mi and 56Mi.
- Keep CPU limits unset for both Tier 1 workloads.

81Mi rounds up the sidecar's 1.25 × 64.55Mi maximum (80.68Mi). The VersityGW limit is 1.25 × the 160Mi censored peak floor. The cluster memory request ratio remains unchanged at 62.93%.

## Verification

- Parsed both values files with Ruby Psych.
- Rendered kube-prometheus-stack 89.2.2 and confirmed the sidecar limit is 81Mi.
- Rendered versitygw chart 0.4.1 and confirmed the gateway limit is 200Mi.
- Ran `git diff --check`.
- Queried the local Prometheus API through a pod port-forward for 14-day and 30-day resource history.
- Confirmed both crash loops terminate with `OOMKilled` and exit code 137.
