### PR TITLE
fix(k8s): size Thanos sidecar from full peak

### DIFF
--- a/values/kube-prometheus-stack/backbone.yaml
+++ b/values/kube-prometheus-stack/backbone.yaml
@@ -914,7 +914,7 @@ prometheus:
           cpu: 10m
           memory: 40Mi
         limits:
-          memory: 81Mi
+          memory: 192Mi
       objectStorageConfig:
         existingSecret:
           name: thanos-objstore-config


### PR DESCRIPTION
## Why

After PR #336 deployed an 81Mi limit, `thanos-sidecar` was still OOM-killed three times while uploading block `01M21D44ANG04M6EMS54EW5KXC`.

The earlier calculation aggregated each five-minute evaluation before taking the range maximum. That method missed short-lived containers and their upload peaks. The correct query takes each container series' full-resolution range maximum first, then selects the global maximum:

```promql
max(max_over_time(container_memory_working_set_bytes{namespace="prometheus",pod="prometheus-shared-0",container="thanos-sidecar"}[14d]))
```

The measured 14-day and 30-day maximum is 157,794,304 bytes (150.48Mi).

## What

- Raise the Thanos sidecar memory limit from 81Mi to 192Mi.
- Keep the 40Mi memory request and 10m CPU request unchanged.
- Keep the CPU limit unset.

192Mi is the practical rounded quantity above 1.25 × 150.48Mi (188.10Mi). The cluster memory request ratio remains unchanged.

## Verification

- Parsed the values file with Ruby Psych.
- Rendered kube-prometheus-stack 89.2.2 and confirmed `spec.thanos.resources.limits.memory: 192Mi`.
- Ran `git diff --check`.
- Confirmed the 81Mi rollout continued to OOM during the same block upload.
