### PR TITLE
fix(k8s): restore safe Thanos sidecar ceiling

### DIFF
--- a/values/kube-prometheus-stack/backbone.yaml
+++ b/values/kube-prometheus-stack/backbone.yaml
@@ -914,7 +914,7 @@ prometheus:
           cpu: 10m
           memory: 40Mi
         limits:
-          memory: 192Mi
+          memory: 480Mi
       objectStorageConfig:
         existingSecret:
           name: thanos-objstore-config


### PR DESCRIPTION
## Why

The 192Mi rollout restored service, but the Thanos sidecar still OOM-killed twice while draining the upload backlog. The current pod reached 191.96Mi total memory and recorded a 196.48Mi cgroup maximum, so 192Mi is not a safe blast wall.

The longer operational history records the same sidecar reaching about 383Mi at a 384Mi limit. That observation is censored by the old limit, but it is the highest known legitimate block-shipping peak. The limit was subsequently raised to 768Mi and operated without this failure before the September 9, 2026 resource reductions.

## What

- Raise the Thanos sidecar memory limit from 192Mi to 480Mi.
- Keep the 40Mi memory request and 10m CPU request unchanged.
- Keep the CPU limit unset.

480Mi is the rounded result of applying the repository's 1.25 blast-wall factor to the documented 383Mi peak. Requests remain unchanged, so scheduling and the cluster memory request ratio are unaffected.

## Verification

- Parsed the values file with Ruby Psych.
- Rendered kube-prometheus-stack 89.2.2 and confirmed `spec.thanos.resources.limits.memory: 480Mi`.
- Ran `git diff --check`.
- Confirmed the 192Mi rollout had two OOM terminations before stabilizing.
