### PR TITLE
fix(buildkit): reserve disk space for release linking

### DIFF
--- a/apps/objects/buildkit/pvc.yaml
+++ b/apps/objects/buildkit/pvc.yaml
@@ -9,4 +9,5 @@ spec:
   storageClassName: ssd-ha-xfs
   resources:
     requests:
-      storage: 50Gi
+      # Leave scratch space above the 45GB cache target for release linking.
+      storage: 100Gi


### PR DESCRIPTION
## Problem
The cc-lb 0.4.7 release artifact check failed during final Rust/LLVM linking with `No space left on device` (isac322/cc-lb#746, job 102363674692). The shared BuildKit cache PVC is 50Gi; live inspection showed 47.2Gi used and only 2.8Gi available. Cache storage read/write errors were zero, so cache misses were not the cause.

## Change
Expand only `arc-systems/buildkit-cache` from 50Gi to 100Gi. Keep the existing 45GB cache target, builder image, deployment, concurrency, resource limits, and GC policy unchanged. This provides scratch space for active release compilation without pruning shared caches or restarting builds.

## Verification
- The only semantic manifest change is the requested PVC capacity.
- Existing StorageClass `ssd-ha-xfs` has `allowVolumeExpansion: true` and uses XFS.
- The BuildKit Argo application uses normal automated reconciliation, without Force/Replace sync options.
- User explicitly approved this separate homelab capacity change and the worktree/PR merge workflow.

After merge, verify PVC/PV capacity and the mounted filesystem reach 100Gi, with the existing builder pod retained, before resuming release validation. No failed CI job has been rerun.