### PR TITLE
chore(ci): roll out gh-enabled cc-lb runners

### DIFF
--- a/values/gha-runner-scale-set/cc-lb-1.yaml
+++ b/values/gha-runner-scale-set/cc-lb-1.yaml
@@ -26,7 +26,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-fe7ac6d6df4f@sha256:c2f09887524d6616d0b97be3316822b47466f5633409f743d6e1bab277deefb4
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS

--- a/values/gha-runner-scale-set/cc-lb-2.yaml
+++ b/values/gha-runner-scale-set/cc-lb-2.yaml
@@ -25,7 +25,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-fe7ac6d6df4f@sha256:c2f09887524d6616d0b97be3316822b47466f5633409f743d6e1bab277deefb4
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS

--- a/values/gha-runner-scale-set/cc-lb-4.yaml
+++ b/values/gha-runner-scale-set/cc-lb-4.yaml
@@ -25,7 +25,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-fe7ac6d6df4f@sha256:c2f09887524d6616d0b97be3316822b47466f5633409f743d6e1bab277deefb4
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS

--- a/values/gha-runner-scale-set/cc-lb-500m.yaml
+++ b/values/gha-runner-scale-set/cc-lb-500m.yaml
@@ -26,7 +26,7 @@ template:
   spec:
     containers:
       - name: runner
-        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-91f8035a0c5f@sha256:508df5d4504e09e2d560b61ef297e2fa77f5e671409c4d8214887a3d8e7327d0
+        image: ghcr.io/isac322/cc-lb-actions-runner:2.337.0-cclb-fe7ac6d6df4f@sha256:c2f09887524d6616d0b97be3316822b47466f5633409f743d6e1bab277deefb4
         command: ["/home/runner/run.sh"]
         env:
           - name: ACTIONS_RUNNER_CONTAINER_HOOKS


### PR DESCRIPTION
## Summary
- pin all four cc-lb ARC runner scale sets to the immutable image built from cc-lb master commit fe7ac6d6df4ff6bba1c6691998c6209ea2e07401
- deploy GitHub CLI 2.100.0 and the Wolfi ldd compatibility wrapper without changing runner resources, environment, volumes, or scaling

## Image
- tag: 2.337.0-cclb-fe7ac6d6df4f
- digest: sha256:c2f09887524d6616d0b97be3316822b47466f5633409f743d6e1bab277deefb4

## Verification
- published image is anonymously pullable and resolves to the pinned digest
- image runs as uid 1001 with gh 2.100.0
- GNU-compatible ldd version banner and normal dependency inspection both passed
- Helm 0.14.2 renders succeeded for cc-lb-500m, cc-lb-1, cc-lb-2, and cc-lb-4
- each rendered manifest contains exactly one final image reference
- git diff --check passed