### PR TITLE
fix(buildkit): cap worker parallelism at one

### DIFF
--- a/apps/objects/buildkit/configmap.yaml
+++ b/apps/objects/buildkit/configmap.yaml
@@ -21,7 +21,7 @@ data:
       reservedSpace = "10GB"
       maxUsedSpace = "45GB"
       minFreeSpace = "5GB"
-      max-parallelism = 2
+      max-parallelism = 1
 
       [[worker.oci.gcpolicy]]
         keepDuration = "48h"

--- a/apps/objects/buildkit/deployment.yaml
+++ b/apps/objects/buildkit/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         app: buildkit
       annotations:
-        checksum/config: b80dda73916f8f9460d1fed69261c1d4f44f56be872c1a9f648f7d08d4a18e32
+        checksum/config: 96057d44907834d328d7a09b05715b44ca061c68d5b75def52f8c11367d90334
     spec:
       terminationGracePeriodSeconds: 30
       affinity:


### PR DESCRIPTION
Two concurrent cc-lb fat-LTO links need ~8Gi anon each and exceed the BuildKit 10Gi cgroup (`ResourceExhausted` / SIGKILL). That is what failed the v0.4.7 `release-server` image publish retry.

Lower `worker.oci.max-parallelism` from 2 to 1 and refresh `checksum/config` so Argo Recreates the daemon.

Measured on this worker: 1-arch linux/arm64 fat LTO, `CARGO_BUILD_JOBS=6`, rustc Anonymous peak 7.82 GiB; pod `memory.current` 9.85 GiB including file cache.